### PR TITLE
Adds getStats() method to QuicTransportBase.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -535,7 +535,7 @@ dictionary QuicTransportStats {
   unsigned long numIncomingStreamsCreated;
   unsigned long long bytesReceived;
   unsigned long long packetsReceived;
-  DOMHighResTimeStamp minRttUs;
+  DOMHighResTimeStamp minRtt;
   unsigned long numReceivedDatagramsDropped;
 };
 </pre>
@@ -546,22 +546,22 @@ The dictionary SHALL have the following attributes:
 :: The `timestamp` for when the stats are gathered, relative to the
 UNIX epoch (Jan 1, 1970, UTC).
 : <dfn for="QuicTransportStats" dict-member>bytesSent</dfn>
-:: The amount of bytes sent on the QUIC connection, including retransmissions.
+:: The number of bytes sent on the QUIC connection, including retransmissions.
 Does not include UDP or any other outer framing.
 : <dfn for="QuicTransportStats" dict-member>packetsSent</dfn>
-:: The amount of packets sent on the QUIC connection, including retransmissions.
+:: The number of packets sent on the QUIC connection, including retransmissions.
 : <dfn for="QuicTransportStats" dict-member>numOutgoingStreamsCreated</dfn>
-:: The amount of outgoing QUIC streams created on the QUIC connection.
+:: The number of outgoing QUIC streams created on the QUIC connection.
 : <dfn for="QuicTransportStats" dict-member>numIncomingStreamsCreated</dfn>
-:: The amount of incoming QUIC streams created on the QUIC connection.
+:: The number of incoming QUIC streams created on the QUIC connection.
 : <dfn for="QuicTransportStats" dict-member>bytesReceived</dfn>
-:: The amount of total bytes received on the QUIC connection, including
+:: The number of total bytes received on the QUIC connection, including
 duplicate data for streams. Does not include UDP or any other outer framing.
 : <dfn for="QuicTransportStats" dict-member>packetsReceived</dfn>
-:: The amount of total packets received on the QUIC connection, including
+:: The number of total packets received on the QUIC connection, including
 packets that were not processable.
-: <dfn for="QuicTransportStats" dict-member>minRttUs</dfn>
-:: The minimum RTT.
+: <dfn for="QuicTransportStats" dict-member>minRtt</dfn>
+:: The minimum RTT observed on the entire connection.
 : <dfn for="QuicTransportStats" dict-member>numReceivedDatagramsDropped</dfn>
 :: The number of datagrams that were dropped, due to too many datagrams buffered
 between calls to {{receiveDatagrams()}}.

--- a/index.bs
+++ b/index.bs
@@ -478,7 +478,7 @@ The dictionary SHALL have the following attributes:
 
 # `QuicTransportBase` Interface #  {#quic-transport-base}
 
-The `QuicTransportBase` is the base interface for {{QuicTransport}}. Most of
+The `QuicTransportBase` is the base for {{QuicTransport}}. Most of
 the functionality of a `QuicTransport` is in the base class to allow for other
 subclasses (such as a p2p variant) to share the same interface.
 
@@ -535,8 +535,7 @@ dictionary QuicTransportStats {
   unsigned long numIncomingStreamsCreated;
   unsigned long long bytesReceived;
   unsigned long long packetsReceived;
-  unsigned long long minRttUs;
-  unsigned long estimatedBandwidthBps;
+  DOMHighResTimeStamp minRttUs;
   unsigned long numReceivedDatagramsDropped;
 };
 </pre>
@@ -546,10 +545,9 @@ The dictionary SHALL have the following attributes:
 : <dfn for="QuicTransportStats" dict-member>timestamp</dfn>
 :: The `timestamp` for when the stats are gathered, relative to the
 UNIX epoch (Jan 1, 1970, UTC).
-
 : <dfn for="QuicTransportStats" dict-member>bytesSent</dfn>
 :: The amount of bytes sent on the QUIC connection, including retransmissions.
-Does not include UDP/IP/ethernet framing.
+Does not include UDP or any other outer framing.
 : <dfn for="QuicTransportStats" dict-member>packetsSent</dfn>
 :: The amount of packets sent on the QUIC connection, including retransmissions.
 : <dfn for="QuicTransportStats" dict-member>numOutgoingStreamsCreated</dfn>
@@ -558,15 +556,12 @@ Does not include UDP/IP/ethernet framing.
 :: The amount of incoming QUIC streams created on the QUIC connection.
 : <dfn for="QuicTransportStats" dict-member>bytesReceived</dfn>
 :: The amount of total bytes received on the QUIC connection, including
-duplicate data for streams. Does not include UDP/IP/ethernet framing.
+duplicate data for streams. Does not include UDP or any other outer framing.
 : <dfn for="QuicTransportStats" dict-member>packetsReceived</dfn>
 :: The amount of total packets received on the QUIC connection, including
 packets that were not processable.
 : <dfn for="QuicTransportStats" dict-member>minRttUs</dfn>
-:: The minimum RTT in microseconds.
-: <dfn for="QuicTransportStats" dict-member>estimatedBandwidthBps</dfn>
-:: The estimated bandwidth in bits per second determined by the QUIC
-connection.
+:: The minimum RTT.
 : <dfn for="QuicTransportStats" dict-member>numReceivedDatagramsDropped</dfn>
 :: The number of datagrams that were dropped, due to too many datagrams buffered
 between calls to {{receiveDatagrams()}}.

--- a/index.html
+++ b/index.html
@@ -2034,7 +2034,7 @@ frame.</p>
      <p>The reason for closing the <code class="idl"><a data-link-type="idl" href="#webtransport" id="ref-for-webtransport④">WebTransport</a></code>.</p>
    </dl>
    <h2 class="heading settled" data-level="8" id="quic-transport-base"><span class="secno">8. </span><span class="content"><code>QuicTransportBase</code> Interface</span><a class="self-link" href="#quic-transport-base"></a></h2>
-   <p>The <code>QuicTransportBase</code> is the base interface for <code class="idl"><a data-link-type="idl" href="#quictransport" id="ref-for-quictransport">QuicTransport</a></code>. Most of
+   <p>The <code>QuicTransportBase</code> is the base for <code class="idl"><a data-link-type="idl" href="#quictransport" id="ref-for-quictransport">QuicTransport</a></code>. Most of
 the functionality of a <code>QuicTransport</code> is in the base class to allow for other
 subclasses (such as a p2p variant) to share the same interface.</p>
    <h3 class="heading settled" data-level="8.1" id="quic-transport-base-overview"><span class="secno">8.1. </span><span class="content">Overview</span><a class="self-link" href="#quic-transport-base-overview"></a></h3>
@@ -2089,46 +2089,41 @@ on QUIC connection level stats.</p>
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numincomingstreamscreated" id="ref-for-dom-quictransportstats-numincomingstreamscreated"><c- g>numIncomingStreamsCreated</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long②"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytesreceived" id="ref-for-dom-quictransportstats-bytesreceived"><c- g>bytesReceived</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long③"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetsreceived" id="ref-for-dom-quictransportstats-packetsreceived"><c- g>packetsReceived</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long④"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-minrttus" id="ref-for-dom-quictransportstats-minrttus"><c- g>minRttUs</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-estimatedbandwidthbps" id="ref-for-dom-quictransportstats-estimatedbandwidthbps"><c- g>estimatedBandwidthBps</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numreceiveddatagramsdropped" id="ref-for-dom-quictransportstats-numreceiveddatagramsdropped"><c- g>numReceivedDatagramsDropped</c-></a>;
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrttus" id="ref-for-dom-quictransportstats-minrttus"><c- g>minRttUs</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numreceiveddatagramsdropped" id="ref-for-dom-quictransportstats-numreceiveddatagramsdropped"><c- g>numReceivedDatagramsDropped</c-></a>;
 };
 </pre>
    <p>The dictionary SHALL have the following attributes:</p>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-timestamp"><code>timestamp</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①">DOMHighResTimeStamp</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-timestamp"><code>timestamp</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp②">DOMHighResTimeStamp</a></span>
     <dd data-md>
      <p>The <code>timestamp</code> for when the stats are gathered, relative to the
 UNIX epoch (Jan 1, 1970, UTC).</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-bytessent"><code>bytesSent</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑤">unsigned long long</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-bytessent"><code>bytesSent</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long④">unsigned long long</a></span>
     <dd data-md>
      <p>The amount of bytes sent on the QUIC connection, including retransmissions.
-Does not include UDP/IP/ethernet framing.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-packetssent"><code>packetsSent</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑥">unsigned long long</a></span>
+Does not include UDP or any other outer framing.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-packetssent"><code>packetsSent</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑤">unsigned long long</a></span>
     <dd data-md>
      <p>The amount of packets sent on the QUIC connection, including retransmissions.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-numoutgoingstreamscreated"><code>numOutgoingStreamsCreated</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④">unsigned long</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-numoutgoingstreamscreated"><code>numOutgoingStreamsCreated</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③">unsigned long</a></span>
     <dd data-md>
      <p>The amount of outgoing QUIC streams created on the QUIC connection.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-numincomingstreamscreated"><code>numIncomingStreamsCreated</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤">unsigned long</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-numincomingstreamscreated"><code>numIncomingStreamsCreated</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④">unsigned long</a></span>
     <dd data-md>
      <p>The amount of incoming QUIC streams created on the QUIC connection.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-bytesreceived"><code>bytesReceived</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑦">unsigned long long</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-bytesreceived"><code>bytesReceived</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑥">unsigned long long</a></span>
     <dd data-md>
      <p>The amount of total bytes received on the QUIC connection, including
-duplicate data for streams. Does not include UDP/IP/ethernet framing.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-packetsreceived"><code>packetsReceived</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑧">unsigned long long</a></span>
+duplicate data for streams. Does not include UDP or any other outer framing.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-packetsreceived"><code>packetsReceived</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑦">unsigned long long</a></span>
     <dd data-md>
      <p>The amount of total packets received on the QUIC connection, including
 packets that were not processable.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-minrttus"><code>minRttUs</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑨">unsigned long long</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-minrttus"><code>minRttUs</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp③">DOMHighResTimeStamp</a></span>
     <dd data-md>
-     <p>The minimum RTT in microseconds.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-estimatedbandwidthbps"><code>estimatedBandwidthBps</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥">unsigned long</a></span>
-    <dd data-md>
-     <p>The estimated bandwidth in bits per second determined by the QUIC
-connection.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-numreceiveddatagramsdropped"><code>numReceivedDatagramsDropped</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑦">unsigned long</a></span>
+     <p>The minimum RTT.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-numreceiveddatagramsdropped"><code>numReceivedDatagramsDropped</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤">unsigned long</a></span>
     <dd data-md>
      <p>The number of datagrams that were dropped, due to too many datagrams buffered
 between calls to <code class="idl"><a data-link-type="idl" href="#dom-datagramtransport-receivedatagrams" id="ref-for-dom-datagramtransport-receivedatagrams①">receiveDatagrams()</a></code>.</p>
@@ -2336,13 +2331,13 @@ either a <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref
    <p>A collection of common attributes and methods of all streams.</p>
 <pre class="idl highlight def">[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③"><c- g>Exposed</c-></a>=<c- n>Window</c-> ]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="webtransportstream"><code><c- g>WebTransportStream</c-></code></dfn> {
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①⓪"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long long" href="#dom-webtransportstream-streamid" id="ref-for-dom-webtransportstream-streamid"><c- g>streamId</c-></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑧"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long long" href="#dom-webtransportstream-streamid" id="ref-for-dom-webtransportstream-streamid"><c- g>streamId</c-></a>;
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#webtransport" id="ref-for-webtransport①⓪"><c- n>WebTransport</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WebTransport" href="#dom-webtransportstream-transport" id="ref-for-dom-webtransportstream-transport"><c- g>transport</c-></a>;
 };
 </pre>
    <h3 class="heading settled" data-level="12.1" id="web-transport-stream-attributes"><span class="secno">12.1. </span><span class="content">Attributes</span><a class="self-link" href="#web-transport-stream-attributes"></a></h3>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WebTransportStream" data-dfn-type="attribute" data-export id="dom-webtransportstream-streamid"><code>streamId</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①①">unsigned long long</a>, readonly</span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WebTransportStream" data-dfn-type="attribute" data-export id="dom-webtransportstream-streamid"><code>streamId</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑨">unsigned long long</a>, readonly</span>
     <dd data-md>
      <p>The readonly attribute referring to the ID of the <code class="idl"><a data-link-type="idl" href="#webtransportstream" id="ref-for-webtransportstream">WebTransportStream</a></code> object.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="WebTransportStream" data-dfn-type="attribute" data-export id="dom-webtransportstream-transport"><code>transport</code></dfn>, <span> of type <a data-link-type="idl-name" href="#webtransport" id="ref-for-webtransport①①">WebTransport</a>, readonly</span>
@@ -2694,7 +2689,6 @@ use in this specification.</p>
      <li><a href="#dom-streamabortinfo-errorcode">dict-member for StreamAbortInfo</a><span>, in §10.4</span>
      <li><a href="#dom-webtransportcloseinfo-errorcode">dict-member for WebTransportCloseInfo</a><span>, in §7.4</span>
     </ul>
-   <li><a href="#dom-quictransportstats-estimatedbandwidthbps">estimatedBandwidthBps</a><span>, in §8.4</span>
    <li><a href="#dom-webtransportstate-failed">"failed"</a><span>, in §7.3</span>
    <li><a href="#dom-quictransportbase-getstats">getStats()</a><span>, in §8.3</span>
    <li><a href="#http3transport">Http3Transport</a><span>, in §16.1</span>
@@ -2806,7 +2800,7 @@ use in this specification.</p>
   <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
    <a href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp">https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-domhighrestimestamp">8.4. QuicTransportStats Dictionary</a> <a href="#ref-for-dom-domhighrestimestamp①">(2)</a>
+    <li><a href="#ref-for-dom-domhighrestimestamp">8.4. QuicTransportStats Dictionary</a> <a href="#ref-for-dom-domhighrestimestamp①">(2)</a> <a href="#ref-for-dom-domhighrestimestamp②">(3)</a> <a href="#ref-for-dom-domhighrestimestamp③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-errorevent">
@@ -2923,15 +2917,15 @@ use in this specification.</p>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
    <a href="https://heycam.github.io/webidl/#idl-unsigned-long">https://heycam.github.io/webidl/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-unsigned-long">8.4. QuicTransportStats Dictionary</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a> <a href="#ref-for-idl-unsigned-long③">(4)</a> <a href="#ref-for-idl-unsigned-long④">(5)</a> <a href="#ref-for-idl-unsigned-long⑤">(6)</a> <a href="#ref-for-idl-unsigned-long⑥">(7)</a> <a href="#ref-for-idl-unsigned-long⑦">(8)</a>
+    <li><a href="#ref-for-idl-unsigned-long">8.4. QuicTransportStats Dictionary</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a> <a href="#ref-for-idl-unsigned-long③">(4)</a> <a href="#ref-for-idl-unsigned-long④">(5)</a> <a href="#ref-for-idl-unsigned-long⑤">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
    <a href="https://heycam.github.io/webidl/#idl-unsigned-long-long">https://heycam.github.io/webidl/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-unsigned-long-long">8.4. QuicTransportStats Dictionary</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a> <a href="#ref-for-idl-unsigned-long-long②">(3)</a> <a href="#ref-for-idl-unsigned-long-long③">(4)</a> <a href="#ref-for-idl-unsigned-long-long④">(5)</a> <a href="#ref-for-idl-unsigned-long-long⑤">(6)</a> <a href="#ref-for-idl-unsigned-long-long⑥">(7)</a> <a href="#ref-for-idl-unsigned-long-long⑦">(8)</a> <a href="#ref-for-idl-unsigned-long-long⑧">(9)</a> <a href="#ref-for-idl-unsigned-long-long⑨">(10)</a>
-    <li><a href="#ref-for-idl-unsigned-long-long①⓪">12. Interface WebTransportStream</a>
-    <li><a href="#ref-for-idl-unsigned-long-long①①">12.1. Attributes</a>
+    <li><a href="#ref-for-idl-unsigned-long-long">8.4. QuicTransportStats Dictionary</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a> <a href="#ref-for-idl-unsigned-long-long②">(3)</a> <a href="#ref-for-idl-unsigned-long-long③">(4)</a> <a href="#ref-for-idl-unsigned-long-long④">(5)</a> <a href="#ref-for-idl-unsigned-long-long⑤">(6)</a> <a href="#ref-for-idl-unsigned-long-long⑥">(7)</a> <a href="#ref-for-idl-unsigned-long-long⑦">(8)</a>
+    <li><a href="#ref-for-idl-unsigned-long-long⑧">12. Interface WebTransportStream</a>
+    <li><a href="#ref-for-idl-unsigned-long-long⑨">12.1. Attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
@@ -3116,16 +3110,15 @@ use in this specification.</p>
 <a class="n" data-link-type="idl-name" href="#quictransportbase" id="ref-for-quictransportbase④①"><c- n>QuicTransportBase</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#webtransport" id="ref-for-webtransport⑤①"><c- n>WebTransport</c-></a>;
 
 <c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportstats" id="ref-for-dictdef-quictransportstats②①"><c- g>QuicTransportStats</c-></a> {
-  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp②"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-timestamp" id="ref-for-dom-quictransportstats-timestamp①"><c- g>timestamp</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①②"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytessent" id="ref-for-dom-quictransportstats-bytessent①"><c- g>bytesSent</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①③"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetssent" id="ref-for-dom-quictransportstats-packetssent①"><c- g>packetsSent</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑧"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numoutgoingstreamscreated" id="ref-for-dom-quictransportstats-numoutgoingstreamscreated①"><c- g>numOutgoingStreamsCreated</c-></a>;
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp④"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-timestamp" id="ref-for-dom-quictransportstats-timestamp①"><c- g>timestamp</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①⓪"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytessent" id="ref-for-dom-quictransportstats-bytessent①"><c- g>bytesSent</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetssent" id="ref-for-dom-quictransportstats-packetssent①"><c- g>packetsSent</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numoutgoingstreamscreated" id="ref-for-dom-quictransportstats-numoutgoingstreamscreated①"><c- g>numOutgoingStreamsCreated</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numincomingstreamscreated" id="ref-for-dom-quictransportstats-numincomingstreamscreated①"><c- g>numIncomingStreamsCreated</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long②①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytesreceived" id="ref-for-dom-quictransportstats-bytesreceived①"><c- g>bytesReceived</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long③①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetsreceived" id="ref-for-dom-quictransportstats-packetsreceived①"><c- g>packetsReceived</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long④①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-minrttus" id="ref-for-dom-quictransportstats-minrttus①"><c- g>minRttUs</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-estimatedbandwidthbps" id="ref-for-dom-quictransportstats-estimatedbandwidthbps①"><c- g>estimatedBandwidthBps</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numreceiveddatagramsdropped" id="ref-for-dom-quictransportstats-numreceiveddatagramsdropped①"><c- g>numReceivedDatagramsDropped</c-></a>;
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrttus" id="ref-for-dom-quictransportstats-minrttus①"><c- g>minRttUs</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numreceiveddatagramsdropped" id="ref-for-dom-quictransportstats-numreceiveddatagramsdropped①"><c- g>numReceivedDatagramsDropped</c-></a>;
 };
 
 [<a href="#dom-quictransport-quictransport"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a> <a href="#dom-quictransport-quictransport-host-port-host"><code><c- g>host</c-></code></a>, <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short④①"><c- b>unsigned</c-> <c- b>short</c-></a> <a href="#dom-quictransport-quictransport-host-port-port"><code><c- g>port</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑧"><c- g>Exposed</c-></a>=<c- n>Window</c->]
@@ -3152,7 +3145,7 @@ use in this specification.</p>
 
 [ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③①"><c- g>Exposed</c-></a>=<c- n>Window</c-> ]
 <c- b>interface</c-> <a href="#webtransportstream"><code><c- g>WebTransportStream</c-></code></a> {
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①⓪①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long long" href="#dom-webtransportstream-streamid" id="ref-for-dom-webtransportstream-streamid①"><c- g>streamId</c-></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑧①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long long" href="#dom-webtransportstream-streamid" id="ref-for-dom-webtransportstream-streamid①"><c- g>streamId</c-></a>;
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#webtransport" id="ref-for-webtransport①⓪①"><c- n>WebTransport</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WebTransport" href="#dom-webtransportstream-transport" id="ref-for-dom-webtransportstream-transport①"><c- g>transport</c-></a>;
 };
 
@@ -3466,12 +3459,6 @@ use in this specification.</p>
    <b><a href="#dom-quictransportstats-minrttus">#dom-quictransportstats-minrttus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-quictransportstats-minrttus">8.4. QuicTransportStats Dictionary</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-quictransportstats-estimatedbandwidthbps">
-   <b><a href="#dom-quictransportstats-estimatedbandwidthbps">#dom-quictransportstats-estimatedbandwidthbps</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-quictransportstats-estimatedbandwidthbps">8.4. QuicTransportStats Dictionary</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-quictransportstats-numreceiveddatagramsdropped">

--- a/index.html
+++ b/index.html
@@ -987,10 +987,9 @@ dictionary WebTransportCloseInfo {
   </section>
 
   <section id="quic-transport-base*">
-    <h2><dfn>QuicTransportBase</dfn> Interface</h2>
-    <p>The <code>QuicTransportBase</code> is the base interface
-      for <code>QuicTransport</code>.  Most of the functionality of a
-      QuicTransport is in the base class to allow for other
+    <h2><dfn>QuicTransportBase</dfn> Mixin</h2>
+    <p>The <code>QuicTransportBase</code> is the base for <code>QuicTransport</code>.
+      Most of the functionality of a QuicTransport is in the base class to allow for other
       subclasses (such as a p2p variant) to share the same interface.
     </p>
     <section id="quictransportbase-overview*">
@@ -1009,12 +1008,213 @@ dictionary WebTransportCloseInfo {
       <div>
         <pre class="idl">
 interface QuicTransportBase {
+    Promise&lt;QuicTransportStats&gt; getStats();
 };
 
 QuicTransportBase includes UnidirectionalStreamsTransport;
 QuicTransportBase includes BidirectionalStreamsTransport;
 QuicTransportBase includes DatagramTransport;
 QuicTransportBase includes WebTransport;</pre>
+      </div>
+    </section>
+    <section>
+      <h2>Methods</h2>
+      <dl data-link-for="QuicTransportBase" data-dfn-for="QuicTransportBase" class=
+      "methods">
+       <dt><dfn><code>getStats</code></dfn></dt>
+        <dd>
+        <p>Gathers stats for this <code><a>QuicTransportBase</a></code>'s QUIC connection and reports
+        the result asynchronously.</p>
+          <p>When <code>getStats</code> is called, the user agent <em class="rfc2119" title="MUST">MUST</em>
+          run the following steps:</p>
+          <ol>
+            <li>Let <var>transport</var> be the <code><a>QuicTransportBase</a></code>
+            on which <code>getStats</code> is invoked.</li>
+            <li>If <var>transport</var>'s <a>[[\WebTransportState]]</a> is <code>"new"</code>
+            then abort these steps.</li>
+            <li>Return <var>p</var> and continue the following steps in the background.</li>
+            <ol>
+              <li>Gather the stats from the underlying QUIC connection.</li>
+              <li>Once stats have been gathered, resolve <var>p</var> with the
+              <code><a>QuicTransportStats</a></code> object, representing the gathered
+              stats</li>
+            </ol>
+          </ol>
+          <div>
+            <em>No parameters.</em>
+          </div>
+          <div>
+            <em>Return type:</em> <code><a>QuicTransportStats</a></code>
+          </div>
+        </dd>
+    </section>
+    <section id="quictransportstats*">
+      <h3><dfn>QuicTransportStats</dfn> Dictionary</h3>
+      <p>The <code>QuicTransportStats</code> dictionary includes information
+      QUIC connection level stats.
+      <div>
+        <pre class="idl">
+dictionary QuicTransportStats {
+  DOMHighResTimeStamp timestamp;
+  unsigned long long bytesSent;
+  unsigned long long packetsSent;
+  unsigned long long streamBytesSent;
+  unsigned long long streamBytesReceived;
+  unsigned long numOutgoingStreamsCreated;
+  unsigned long numIncomingStreamsCreated;
+  unsigned long long bytesReceived;
+  unsigned long long packetsReceived;
+  unsigned long long packetsProcessed;
+  unsigned long long bytesRetransmitted;
+  unsigned long long packetsRetransmitted;
+  unsigned long long packetsLost;
+  unsigned long long packetsDropped;
+  unsigned long long cryptoRetransmitCount;
+  unsigned long long minRttUs;
+  unsigned long long smoothedRttUs;
+  unsigned short maxPacketSize;
+  unsigned short maxReceivedPacketSize;
+  unsigned long estimatedBandwidthBps;
+  unsigned long long packetsReordered;
+  unsigned long long blockedFramesReceived;
+  unsigned long long blockedFramesSent;
+  unsigned long long connectivityProbingPacketsReceived;
+};</pre>
+        <section>
+          <h2>Dictionary <a class="idlType">QuicTransportStats</a> Members</h2>
+          <dl data-link-for="QuicTransportStats" data-dfn-for="QuicTransportStats" class=
+          "dictionary-members">
+            <dt><dfn><code>timestamp</code></dfn> of type <span class=
+            "idlMemberType"><a>DOMHighResTimeStamp</a></span></dt>
+            <dd>
+              <p>The <code>timestamp</code> for when the stats are gathered, relative to the
+              UNIX epoch (Jan 1, 1970, UTC)</p>
+            </dd>
+            <dt><dfn><code>bytesSent</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of bytes sent on the QUIC connection, including
+              retransmissions.</p>
+            </dd>
+            <dt><dfn><code>packetsSent</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of packets sent</code> on the QUIC connection, including
+              retransmissions.</p>
+            </dd>
+            <dt><dfn><code>streamBytesSent</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of stream bytes sent on the QUIC connection, not including
+              retransmissions.</p>
+            </dd>
+            <dt><dfn><code>streamBytesReceived</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of stream bytes received on the QUIC connection, not including
+              retransmissions.</p>
+            </dd>
+            <dt><dfn><code>numOutgoingStreamsCreated</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long</a></span></dt>
+            <dd>
+              <p>The amount of outgoing QUIC streams created on the QUIC connection.</p>
+            </dd>
+            <dt><dfn><code>numIncomingStreamsCreated</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long</a></span></dt>
+            <dd>
+              <p>The amount of incoming QUIC streams created on the QUIC connection.</p>
+            </dd>
+            <dt><dfn><code>bytesReceived</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of total bytes received on the QUIC connection, including
+              duplicate data for streams.</p>
+            </dd>
+            <dt><dfn><code>packetsReceived</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of total bytes received on the QUIC connection, including
+              packets that were not processable.</p>
+            </dd>
+            <dt><dfn><code>packetsProcessed</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of total packets processed on the QUIC connection.</p>
+            </dd>
+            <dt><dfn><code>bytesRetransmitted</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of bytes retransmitted on the QUIC connection.</p>
+            </dd>
+            <dt><dfn><code>packetsRetransmitted</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of packets retransmitted on the QUIC connection.</p>
+            </dd>
+            <dt><dfn><code>packetsLost</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of packets abandoned as lost determined by the loss detection
+              algorithm.</p>
+            </dd>
+            <dt><dfn><code>packetsDropped</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of packets dropped.</p>
+            </dd>
+            <dt><dfn><code>cryptoRetransmitCount</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The amount of crypto retransmissions.</p>
+            </dd>
+            <dt><dfn><code>minRttUs</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The minimum RTT in microseconds.</p>
+            </dd>
+            <dt><dfn><code>smoothedRttUs</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>The smoothed RTT in microseconds.</p>
+            </dd>
+            <dt><dfn><code>maxPacketSize</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned short</a></span></dt>
+            <dd>
+              <p>The maximum packet size to be sent on a QUIC connection.</p>
+            </dd>
+            <dt><dfn><code>maxReceivedPacketSize</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned short</a></span></dt>
+            <dd>
+              <p>The maximum received packet size on a QUIC connection.</p>
+            </dd>
+            <dt><dfn><code>estimatedBandwidthBps</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long</a></span></dt>
+            <dd>
+              <p>The estimated bandwidth in bits per second determined by the QUIC
+              connection.</p>
+            </dd>
+            <dt><dfn><code>packetsReordered</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>Number of packets received out of packet number order.</p>
+            </dd>
+            <dt><dfn><code>blockedFramesReceived</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>Number of blocked frames received.</p>
+            </dd>
+            <dt><dfn><code>blockedFramesSent</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>Number of blocked frames sent.</p>
+            </dd>
+            <dt><dfn><code>connectivityProbingPacketsReceived</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long long</a></span></dt>
+            <dd>
+              <p>Number of connectivity probing packets received.</p>
+            </dd>
+          </dl>
+        </section>
       </div>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -719,9 +719,8 @@ interface mixin DatagramTransport {
           <p>If not, return a new promise that will resolve when more datagrams are received,
               resolved with all datagrams received. </p>
           <p>If too many datagrams are queued between calls to receiveDatagrams(),
-             the implementation may drop datagrams and replace them with a null value
-             in the sequence of datagrams returned in the next call to receiveDatagrams().
-             One null value may represent many dropped datagrams.<p>
+             the implementation may drop datagrams. This will be reflected in the
+             <code>QuicTransportStats</code>.<p>
           <p>receiveDatagrams() may only be called once at a time.
              If a promised returned from a previous call is still unresolved,
              the user agent MUST return a new promise rejected with an InvalidStateError. </p>
@@ -1079,6 +1078,7 @@ dictionary QuicTransportStats {
   unsigned long long blockedFramesReceived;
   unsigned long long blockedFramesSent;
   unsigned long long connectivityProbingPacketsReceived;
+  unsigned long numReceivedDatagramsDropped;
 };</pre>
         <section>
           <h2>Dictionary <a class="idlType">QuicTransportStats</a> Members</h2>
@@ -1094,7 +1094,7 @@ dictionary QuicTransportStats {
             "idlMemberType"><a>unsigned long long</a></span></dt>
             <dd>
               <p>The amount of bytes sent on the QUIC connection, including
-              retransmissions.</p>
+              retransmissions. Does not include UDP/IP/ethernet framing.</p>
             </dd>
             <dt><dfn><code>packetsSent</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long long</a></span></dt>
@@ -1106,13 +1106,13 @@ dictionary QuicTransportStats {
             "idlMemberType"><a>unsigned long long</a></span></dt>
             <dd>
               <p>The amount of stream bytes sent on the QUIC connection, not including
-              retransmissions.</p>
+              retransmissions. Does not include UDP/IP/ethernet framing.</p>
             </dd>
             <dt><dfn><code>streamBytesReceived</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long long</a></span></dt>
             <dd>
               <p>The amount of stream bytes received on the QUIC connection, not including
-              retransmissions.</p>
+              retransmissions. Does not include UDP/IP/ethernet framing.</p>
             </dd>
             <dt><dfn><code>numOutgoingStreamsCreated</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
@@ -1128,12 +1128,12 @@ dictionary QuicTransportStats {
             "idlMemberType"><a>unsigned long long</a></span></dt>
             <dd>
               <p>The amount of total bytes received on the QUIC connection, including
-              duplicate data for streams.</p>
+              duplicate data for streams. Does not include UDP/IP/ethernet framing.</p>
             </dd>
             <dt><dfn><code>packetsReceived</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long long</a></span></dt>
             <dd>
-              <p>The amount of total bytes received on the QUIC connection, including
+              <p>The amount of total packets received on the QUIC connection, including
               packets that were not processable.</p>
             </dd>
             <dt><dfn><code>packetsProcessed</code></dfn> of type <span class=
@@ -1144,7 +1144,8 @@ dictionary QuicTransportStats {
             <dt><dfn><code>bytesRetransmitted</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long long</a></span></dt>
             <dd>
-              <p>The amount of bytes retransmitted on the QUIC connection.</p>
+              <p>The amount of bytes retransmitted on the QUIC connection.
+              Does not include UDP/IP/ethernet framing.</p>
             </dd>
             <dt><dfn><code>packetsRetransmitted</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long long</a></span></dt>
@@ -1160,7 +1161,7 @@ dictionary QuicTransportStats {
             <dt><dfn><code>packetsDropped</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long long</a></span></dt>
             <dd>
-              <p>The amount of packets dropped.</p>
+              <p>The amount of QUIC packets ignored.</p>
             </dd>
             <dt><dfn><code>cryptoRetransmitCount</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long long</a></span></dt>
@@ -1212,6 +1213,12 @@ dictionary QuicTransportStats {
             "idlMemberType"><a>unsigned long long</a></span></dt>
             <dd>
               <p>Number of connectivity probing packets received.</p>
+            </dd>
+            <dt><dfn><code>numReceivedDatagramsDropped</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long</a></span></dt>
+            <dd>
+              <p>The number of datagrams that were dropped, due to too many datagrams buffered
+              between calls to <code>receiveDatagrams()</code>.</p>
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 08c4b0e94d147852f66673459784d3429bb3bda1" name="generator">
+  <meta content="Bikeshed version f7860c06eaec18afc415bf3f4a7b90aee58ca680" name="generator">
   <link href="https://wicg.github.io/web-transport/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1472,7 +1472,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">WebTransport</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-08-29">29 August 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-09-04">4 September 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2089,7 +2089,7 @@ on QUIC connection level stats.</p>
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numincomingstreamscreated" id="ref-for-dom-quictransportstats-numincomingstreamscreated"><c- g>numIncomingStreamsCreated</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long②"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytesreceived" id="ref-for-dom-quictransportstats-bytesreceived"><c- g>bytesReceived</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long③"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetsreceived" id="ref-for-dom-quictransportstats-packetsreceived"><c- g>packetsReceived</c-></a>;
-  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrttus" id="ref-for-dom-quictransportstats-minrttus"><c- g>minRttUs</c-></a>;
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrtt" id="ref-for-dom-quictransportstats-minrtt"><c- g>minRtt</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numreceiveddatagramsdropped" id="ref-for-dom-quictransportstats-numreceiveddatagramsdropped"><c- g>numReceivedDatagramsDropped</c-></a>;
 };
 </pre>
@@ -2101,28 +2101,28 @@ on QUIC connection level stats.</p>
 UNIX epoch (Jan 1, 1970, UTC).</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-bytessent"><code>bytesSent</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long④">unsigned long long</a></span>
     <dd data-md>
-     <p>The amount of bytes sent on the QUIC connection, including retransmissions.
+     <p>The number of bytes sent on the QUIC connection, including retransmissions.
 Does not include UDP or any other outer framing.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-packetssent"><code>packetsSent</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑤">unsigned long long</a></span>
     <dd data-md>
-     <p>The amount of packets sent on the QUIC connection, including retransmissions.</p>
+     <p>The number of packets sent on the QUIC connection, including retransmissions.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-numoutgoingstreamscreated"><code>numOutgoingStreamsCreated</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③">unsigned long</a></span>
     <dd data-md>
-     <p>The amount of outgoing QUIC streams created on the QUIC connection.</p>
+     <p>The number of outgoing QUIC streams created on the QUIC connection.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-numincomingstreamscreated"><code>numIncomingStreamsCreated</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④">unsigned long</a></span>
     <dd data-md>
-     <p>The amount of incoming QUIC streams created on the QUIC connection.</p>
+     <p>The number of incoming QUIC streams created on the QUIC connection.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-bytesreceived"><code>bytesReceived</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑥">unsigned long long</a></span>
     <dd data-md>
-     <p>The amount of total bytes received on the QUIC connection, including
+     <p>The number of total bytes received on the QUIC connection, including
 duplicate data for streams. Does not include UDP or any other outer framing.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-packetsreceived"><code>packetsReceived</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑦">unsigned long long</a></span>
     <dd data-md>
-     <p>The amount of total packets received on the QUIC connection, including
+     <p>The number of total packets received on the QUIC connection, including
 packets that were not processable.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-minrttus"><code>minRttUs</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp③">DOMHighResTimeStamp</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-minrtt"><code>minRtt</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp③">DOMHighResTimeStamp</a></span>
     <dd data-md>
-     <p>The minimum RTT.</p>
+     <p>The minimum RTT observed on the entire connection.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-numreceiveddatagramsdropped"><code>numReceivedDatagramsDropped</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤">unsigned long</a></span>
     <dd data-md>
      <p>The number of datagrams that were dropped, due to too many datagrams buffered
@@ -2696,7 +2696,7 @@ use in this specification.</p>
    <li><a href="#immediate-close">Immediate Close</a><span>, in §7.2</span>
    <li><a href="#incomingstream">IncomingStream</a><span>, in §11</span>
    <li><a href="#dom-datagramtransport-maxdatagramsize">maxDatagramSize</a><span>, in §6.1</span>
-   <li><a href="#dom-quictransportstats-minrttus">minRttUs</a><span>, in §8.4</span>
+   <li><a href="#dom-quictransportstats-minrtt">minRtt</a><span>, in §8.4</span>
    <li><a href="#dom-webtransportstate-new">"new"</a><span>, in §7.3</span>
    <li><a href="#dom-quictransportstats-numincomingstreamscreated">numIncomingStreamsCreated</a><span>, in §8.4</span>
    <li><a href="#dom-quictransportstats-numoutgoingstreamscreated">numOutgoingStreamsCreated</a><span>, in §8.4</span>
@@ -3117,7 +3117,7 @@ use in this specification.</p>
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numincomingstreamscreated" id="ref-for-dom-quictransportstats-numincomingstreamscreated①"><c- g>numIncomingStreamsCreated</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long②①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytesreceived" id="ref-for-dom-quictransportstats-bytesreceived①"><c- g>bytesReceived</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long③①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetsreceived" id="ref-for-dom-quictransportstats-packetsreceived①"><c- g>packetsReceived</c-></a>;
-  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrttus" id="ref-for-dom-quictransportstats-minrttus①"><c- g>minRttUs</c-></a>;
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrtt" id="ref-for-dom-quictransportstats-minrtt①"><c- g>minRtt</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numreceiveddatagramsdropped" id="ref-for-dom-quictransportstats-numreceiveddatagramsdropped①"><c- g>numReceivedDatagramsDropped</c-></a>;
 };
 
@@ -3455,10 +3455,10 @@ use in this specification.</p>
     <li><a href="#ref-for-dom-quictransportstats-packetsreceived">8.4. QuicTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-quictransportstats-minrttus">
-   <b><a href="#dom-quictransportstats-minrttus">#dom-quictransportstats-minrttus</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-quictransportstats-minrtt">
+   <b><a href="#dom-quictransportstats-minrtt">#dom-quictransportstats-minrtt</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-quictransportstats-minrttus">8.4. QuicTransportStats Dictionary</a>
+    <li><a href="#ref-for-dom-quictransportstats-minrtt">8.4. QuicTransportStats Dictionary</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-quictransportstats-numreceiveddatagramsdropped">

--- a/index.html
+++ b/index.html
@@ -1057,27 +1057,12 @@ dictionary QuicTransportStats {
   DOMHighResTimeStamp timestamp;
   unsigned long long bytesSent;
   unsigned long long packetsSent;
-  unsigned long long streamBytesSent;
-  unsigned long long streamBytesReceived;
   unsigned long numOutgoingStreamsCreated;
   unsigned long numIncomingStreamsCreated;
   unsigned long long bytesReceived;
   unsigned long long packetsReceived;
-  unsigned long long packetsProcessed;
-  unsigned long long bytesRetransmitted;
-  unsigned long long packetsRetransmitted;
-  unsigned long long packetsLost;
-  unsigned long long packetsDropped;
-  unsigned long long cryptoRetransmitCount;
   unsigned long long minRttUs;
-  unsigned long long smoothedRttUs;
-  unsigned short maxPacketSize;
-  unsigned short maxReceivedPacketSize;
   unsigned long estimatedBandwidthBps;
-  unsigned long long packetsReordered;
-  unsigned long long blockedFramesReceived;
-  unsigned long long blockedFramesSent;
-  unsigned long long connectivityProbingPacketsReceived;
   unsigned long numReceivedDatagramsDropped;
 };</pre>
         <section>
@@ -1102,18 +1087,6 @@ dictionary QuicTransportStats {
               <p>The amount of packets sent</code> on the QUIC connection, including
               retransmissions.</p>
             </dd>
-            <dt><dfn><code>streamBytesSent</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>The amount of stream bytes sent on the QUIC connection, not including
-              retransmissions. Does not include UDP/IP/ethernet framing.</p>
-            </dd>
-            <dt><dfn><code>streamBytesReceived</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>The amount of stream bytes received on the QUIC connection, not including
-              retransmissions. Does not include UDP/IP/ethernet framing.</p>
-            </dd>
             <dt><dfn><code>numOutgoingStreamsCreated</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
             <dd>
@@ -1136,83 +1109,16 @@ dictionary QuicTransportStats {
               <p>The amount of total packets received on the QUIC connection, including
               packets that were not processable.</p>
             </dd>
-            <dt><dfn><code>packetsProcessed</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>The amount of total packets processed on the QUIC connection.</p>
-            </dd>
-            <dt><dfn><code>bytesRetransmitted</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>The amount of bytes retransmitted on the QUIC connection.
-              Does not include UDP/IP/ethernet framing.</p>
-            </dd>
-            <dt><dfn><code>packetsRetransmitted</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>The amount of packets retransmitted on the QUIC connection.</p>
-            </dd>
-            <dt><dfn><code>packetsLost</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>The amount of packets abandoned as lost determined by the loss detection
-              algorithm.</p>
-            </dd>
-            <dt><dfn><code>packetsDropped</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>The amount of QUIC packets ignored.</p>
-            </dd>
-            <dt><dfn><code>cryptoRetransmitCount</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>The amount of crypto retransmissions.</p>
-            </dd>
             <dt><dfn><code>minRttUs</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long long</a></span></dt>
             <dd>
               <p>The minimum RTT in microseconds.</p>
-            </dd>
-            <dt><dfn><code>smoothedRttUs</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>The smoothed RTT in microseconds.</p>
-            </dd>
-            <dt><dfn><code>maxPacketSize</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned short</a></span></dt>
-            <dd>
-              <p>The maximum packet size to be sent on a QUIC connection.</p>
-            </dd>
-            <dt><dfn><code>maxReceivedPacketSize</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned short</a></span></dt>
-            <dd>
-              <p>The maximum received packet size on a QUIC connection.</p>
             </dd>
             <dt><dfn><code>estimatedBandwidthBps</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
             <dd>
               <p>The estimated bandwidth in bits per second determined by the QUIC
               connection.</p>
-            </dd>
-            <dt><dfn><code>packetsReordered</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>Number of packets received out of packet number order.</p>
-            </dd>
-            <dt><dfn><code>blockedFramesReceived</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>Number of blocked frames received.</p>
-            </dd>
-            <dt><dfn><code>blockedFramesSent</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>Number of blocked frames sent.</p>
-            </dd>
-            <dt><dfn><code>connectivityProbingPacketsReceived</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long long</a></span></dt>
-            <dd>
-              <p>Number of connectivity probing packets received.</p>
             </dd>
             <dt><dfn><code>numReceivedDatagramsDropped</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>


### PR DESCRIPTION
This basically is just reusing what was implemented in the RTCQuicTransport origin trial. Feel free to suggest removing/editing certain stats. The main motivation for this PR is:
1) Get basic stats in the spec
2) Have a place to point for at least some basic congestion control information exposed in the API.

See issues:
- https://github.com/w3c/webrtc-quic/issues/66 (Initial suggestion for P2P QUIC transport stats)
- https://github.com/WICG/web-transport/issues/21 (bandwidth prediction)