### PR TITLE
Allow QuicTransport to connect to the servers not using a publicly trusted certificate.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -521,21 +521,33 @@ defined in [[!QUIC-DATAGRAM]].
 
 <pre class="idl">
 dictionary QuicTransportConfiguration {
-  sequence&lt;RTCDtlsFingerprint&gt; server_certificates;
+  sequence&lt;RTCDtlsFingerprint&gt; server_certificate_fingerprints;
 };
 </pre>
 
 <dfn dictionary>QuicTransportConfiguration</dfn> is a dictionary of parameters
 that determine how QuicTransport connection is established and used.
 
-: <dfn for="QuicTransportConfiguration" dict-member>server_certificates</dfn>
+: <dfn for="QuicTransportConfiguration" dict-member>server_certificate_fingerprints</dfn>
 :: If non-empty, the user agent SHALL deem a server certificate trusted if and
    only if it matches one of the fingerprints defined in
-   {{QuicTransportConfiguration/server_certificates}}.  The user agent SHALL
-   ignore any fingerprint that uses an unknown {{RTCDtlsFingerprint/algorithm}}
-   or has a malformed {{RTCDtlsFingerprint/value}}.  If empty, the user agent
-   SHALL use certificate verification procedures it would use for normal
-   [=fetch=] operations.
+   {{QuicTransportConfiguration/server_certificate_fingerprints}} and satisfies
+   [=custom certificate requirements=].  The user agent SHALL ignore any
+   fingerprint that uses an unknown {{RTCDtlsFingerprint/algorithm}} or has a
+   malformed {{RTCDtlsFingerprint/value}}.  If empty, the user agent SHALL use
+   certificate verification procedures it would use for normal [=fetch=]
+   operations.
+
+The <dfn>custom certificate requirements</dfn> are as follows: the certificate
+MUST be an X.509v3 certificate as defined in [[!RFC5280]], the current time
+MUST be within the validity period of the certificate as defined in Section
+4.1.2.5 of [[!RFC5280]] and the total length of the validity period MUST NOT
+exceed two weeks.
+
+Issue: Reconsider the time period above.  We want it to be sufficiently large
+that applications using this for ephemeral certificates can do so without
+having to fight the clock skew, but small enough to discourage long-term use
+without key rotation.
 
 ## Interface Definition ##  {#quic-transport-definition}
 

--- a/index.bs
+++ b/index.bs
@@ -531,13 +531,35 @@ that determine how QuicTransport connection is established and used.
 
 : <dfn for="QuicTransportConfiguration" dict-member>server_certificate_fingerprints</dfn>
 :: If non-empty, the user agent SHALL deem a server certificate trusted if and
-   only if it matches one of the fingerprints defined in
+   only if it can successfully [=verify a certificate fingerprint=] against
    {{QuicTransportConfiguration/server_certificate_fingerprints}} and satisfies
    [=custom certificate requirements=].  The user agent SHALL ignore any
    fingerprint that uses an unknown {{RTCDtlsFingerprint/algorithm}} or has a
    malformed {{RTCDtlsFingerprint/value}}.  If empty, the user agent SHALL use
    certificate verification procedures it would use for normal [=fetch=]
    operations.
+
+<div algorithm="compute a certificate fingerprint">
+To <dfn>compute a certificate fingerprint</dfn>, do the following:
+1. Let |cert| be the input certificate, represented as a DER encoding of
+   Certificate message defined in [[!RFC5280]].
+1. Compute the SHA-256 hash of |cert|.  Format it as `fingerprint` BNF
+   rule described in Section 5 of [[!RFC8122]].
+
+</div>
+
+<div algorithm="verify a certificate fingerprint">
+To <dfn>verify a certificate fingerprint</dfn>, do the following:
+1. Let |fprs| be the input array of fingerprints.
+1. Let |ref_fpr| be the [=compute a certificate fingerprint|computed
+   fingerprint=] of the input certificate.
+1. For every fingerprint |fpr| in |fprs|:
+   1. If {{RTCDtlsFingerprint/algorithm}} of |fpr| is equal to "sha-256", and
+      {{RTCDtlsFingerprint/value}} of |fpr| is equal to |ref_fpr|, the
+      certificate is valid.  Return true.
+1. Return false.
+
+</div>
 
 The <dfn>custom certificate requirements</dfn> are as follows: the certificate
 MUST be an X.509v3 certificate as defined in [[!RFC5280]], the current time

--- a/index.bs
+++ b/index.bs
@@ -61,6 +61,7 @@ Boilerplate: omit conformance
 <pre class="link-defaults">
 spec:streams; type:interface; text:ReadableStream
 spec:html; type:dfn; for:/; text:origin
+spec:fetch; type:dfn; for:/; text:fetch
 spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment
 </pre>
@@ -516,11 +517,32 @@ with unidirectional QUIC streams as defined in [[!QUIC-TRANSPORT]].
 defined in [[!QUIC-TRANSPORT]]. Datagrams are implemented with QUIC datagrams as
 defined in [[!QUIC-DATAGRAM]].
 
+## Configuration ##  {#quic-transport-configuration}
+
+<pre class="idl">
+dictionary QuicTransportConfiguration {
+  sequence&lt;RTCDtlsFingerprint&gt; server_certificates;
+};
+</pre>
+
+<dfn dictionary>QuicTransportConfiguration</dfn> is a dictionary of parameters
+that determine how QuicTransport connection is established and used.
+
+: <dfn for="QuicTransportConfiguration" dict-member>server_certificates</dfn>
+:: If non-empty, the user agent SHALL deem a server certificate trusted if and
+   only if it matches one of the fingerprints defined in
+   {{QuicTransportConfiguration/server_certificates}}.  The user agent SHALL
+   ignore any fingerprint that uses an unknown {{RTCDtlsFingerprint/algorithm}}
+   or has a malformed {{RTCDtlsFingerprint/value}}.  If empty, the user agent
+   SHALL use certificate verification procedures it would use for normal
+   [=fetch=] operations.
+
 ## Interface Definition ##  {#quic-transport-definition}
 
 <pre class="idl">
-[Constructor(USVString url), Exposed=(Window,Worker)]
+[Exposed=(Window,Worker)]
 interface QuicTransport {
+  constructor(USVString url, optional QuicTransportConfiguration config = {});
   Promise&lt;QuicTransportStats&gt; getStats();
 };
 
@@ -531,10 +553,10 @@ QuicTransport includes WebTransport;
 </pre>
 
 
-When the {{QuicTransport/QuicTransport()}} constructor is invoked, the user
+When the {{QuicTransport/constructor()}} constructor is invoked, the user
 agent MUST run the following steps:
 1. Let |parsedURL| be the [=URL record=] resulting from [=URL parser|parsing=]
-   of {{QuicTransport/QuicTransport(url)/url}}.
+   of {{QuicTransport/constructor(url, config)/url}}.
 1. If |parsedURL| is a failure, [=throw=] a {{SyntaxError}} exception.
 1. If |parsedURL| [=scheme=] is not `quic-transport`, [=throw=]
    a {{SyntaxError}} exception.
@@ -568,6 +590,8 @@ agent MUST run the following steps:
     1. Establish a QUIC connection to the address identified by |parsedURL|
        following the procedures in [[!WEB-TRANSPORT-QUIC]] section 3 and using
        |clientOrigin| as the "origin of the client" referenced in section 3.2.1.
+       While establishing the connection, follow all of the parameters
+       specified in the {{QuicTransport/constructor(url, config)/config}}.
     1. If the connection fails, set |transport|'s {{[[WebTransportState]]}}
        internal slot to `"failed"` and abort these steps.
     1. Set |transport|'s {{[[WebTransportState]]}} internal slot to

--- a/index.html
+++ b/index.html
@@ -1222,8 +1222,9 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version b43aa594f5014ff14748da1aace9afaa73d2b3e6" name="generator">
   <link href="https://wicg.github.io/web-transport/" rel="canonical">
-  <meta content="188bd8ebc577e8b380cf4c02dfcfe30f697b25f7" name="document-revision">
+  <meta content="868df125fb0903fa56fd029a1274762b581eb13b" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1481,13 +1482,14 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">WebTransport</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-06">6 February 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-18">18 February 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://wicg.github.io/web-transport/">https://wicg.github.io/web-transport/</a>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/wicg/web-transport/issues/">GitHub</a>
+     <dd><a href="#issues-index">Inline In Spec</a>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><span class="p-name fn">Peter Thatcher</span> (<span class="p-org org">Google</span>)
      <dd class="editor p-author h-card vcard"><span class="p-name fn">Bernard Aboba</span> (<span class="p-org org">Microsoft Corporation</span>)
@@ -1625,6 +1627,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
      </ol>
     <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+    <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
    </ol>
   </nav>
   <main>
@@ -2073,19 +2076,29 @@ defined in <a data-link-type="biblio" href="#biblio-quic-transport">[QUIC-TRANSP
 defined in <a data-link-type="biblio" href="#biblio-quic-datagram">[QUIC-DATAGRAM]</a>.</p>
    <h3 class="heading settled" data-level="8.1" id="quic-transport-configuration"><span class="secno">8.1. </span><span class="content">Configuration</span><a class="self-link" href="#quic-transport-configuration"></a></h3>
 <pre class="idl highlight def"><c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportconfiguration" id="ref-for-dictdef-quictransportconfiguration"><c- g>QuicTransportConfiguration</c-></a> {
-  <c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint"><c- n>RTCDtlsFingerprint</c-></a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<RTCDtlsFingerprint> " href="#dom-quictransportconfiguration-server_certificates" id="ref-for-dom-quictransportconfiguration-server_certificates"><c- g>server_certificates</c-></a>;
+  <c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint"><c- n>RTCDtlsFingerprint</c-></a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<RTCDtlsFingerprint> " href="#dom-quictransportconfiguration-server_certificate_fingerprints" id="ref-for-dom-quictransportconfiguration-server_certificate_fingerprints"><c- g>server_certificate_fingerprints</c-></a>;
 };
 </pre>
    <p><dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-quictransportconfiguration"><code>QuicTransportConfiguration</code></dfn> is a dictionary of parameters
 that determine how QuicTransport connection is established and used.</p>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportConfiguration" data-dfn-type="dict-member" data-export id="dom-quictransportconfiguration-server_certificates"><code>server_certificates</code></dfn>, <span> of type sequence&lt;<a data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint①">RTCDtlsFingerprint</a>></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportConfiguration" data-dfn-type="dict-member" data-export id="dom-quictransportconfiguration-server_certificate_fingerprints"><code>server_certificate_fingerprints</code></dfn>, <span> of type sequence&lt;<a data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint①">RTCDtlsFingerprint</a>></span>
     <dd data-md>
      <p>If non-empty, the user agent SHALL deem a server certificate trusted if and
- only if it matches one of the fingerprints defined in <code class="idl"><a data-link-type="idl" href="#dom-quictransportconfiguration-server_certificates" id="ref-for-dom-quictransportconfiguration-server_certificates①">server_certificates</a></code>.  The user agent SHALL
- ignore any fingerprint that uses an unknown <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-algorithm" id="ref-for-dom-rtcdtlsfingerprint-algorithm">algorithm</a></code> or has a malformed <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-value" id="ref-for-dom-rtcdtlsfingerprint-value">value</a></code>.  If empty, the user agent
- SHALL use certificate verification procedures. it would use for normal <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch">fetch</a> operations.</p>
+ only if it matches one of the fingerprints defined in <code class="idl"><a data-link-type="idl" href="#dom-quictransportconfiguration-server_certificate_fingerprints" id="ref-for-dom-quictransportconfiguration-server_certificate_fingerprints①">server_certificate_fingerprints</a></code> and satisfies <a data-link-type="dfn" href="#custom-certificate-requirements" id="ref-for-custom-certificate-requirements">custom certificate requirements</a>.  The user agent SHALL ignore any
+ fingerprint that uses an unknown <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-algorithm" id="ref-for-dom-rtcdtlsfingerprint-algorithm">algorithm</a></code> or has a
+ malformed <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-value" id="ref-for-dom-rtcdtlsfingerprint-value">value</a></code>.  If empty, the user agent SHALL use
+ certificate verification procedures it would use for normal <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch">fetch</a> operations.</p>
    </dl>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="custom-certificate-requirements">custom certificate requirements</dfn> are as follows: the certificate
+MUST be an X.509v3 certificate as defined in <a data-link-type="biblio" href="#biblio-rfc5280">[RFC5280]</a>, the current time
+MUST be within the validity period of the certificate as defined in Section
+4.1.2.5 of <a data-link-type="biblio" href="#biblio-rfc5280">[RFC5280]</a> and the total length of the validity period MUST NOT
+exceed two weeks.</p>
+   <p class="issue" id="issue-7e6950b7"><a class="self-link" href="#issue-7e6950b7"></a> Reconsider the time period above.  We want it to be sufficiently large
+that applications using this for ephemeral certificates can do so without
+having to fight the clock skew, but small enough to discourage long-term use
+without key rotation.</p>
    <h3 class="heading settled" data-level="8.2" id="quic-transport-definition"><span class="secno">8.2. </span><span class="content">Interface Definition</span><a class="self-link" href="#quic-transport-definition"></a></h3>
 <pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#quictransport" id="ref-for-quictransport"><c- g>QuicTransport</c-></a> {
@@ -2658,6 +2671,7 @@ use in this specification.</p>
    <li><a href="#dom-bidirectionalstreamstransport-createbidirectionalstream">createBidirectionalStream()</a><span>, in §5.1</span>
    <li><a href="#dom-unidirectionalstreamstransport-createsendstream">createSendStream()</a><span>, in §4.1</span>
    <li><a href="#dom-unidirectionalstreamstransport-createsendstream">createSendStream(parameters)</a><span>, in §4.1</span>
+   <li><a href="#custom-certificate-requirements">custom certificate requirements</a><span>, in §8.1</span>
    <li><a href="#datagramtransport">DatagramTransport</a><span>, in §6</span>
    <li>
     errorCode
@@ -2701,7 +2715,7 @@ use in this specification.</p>
    <li><a href="#sendstream">SendStream</a><span>, in §12</span>
    <li><a href="#dictdef-sendstreamparameters">SendStreamParameters</a><span>, in §4.3</span>
    <li><a href="#dom-quictransport-sentdatagrams-slot">[[SentDatagrams]]</a><span>, in §8.2</span>
-   <li><a href="#dom-quictransportconfiguration-server_certificates">server_certificates</a><span>, in §8.1</span>
+   <li><a href="#dom-quictransportconfiguration-server_certificate_fingerprints">server_certificate_fingerprints</a><span>, in §8.1</span>
    <li><a href="#dom-webtransport-state">state</a><span>, in §7.1</span>
    <li><a href="#dictdef-streamabortinfo">StreamAbortInfo</a><span>, in §9.4</span>
    <li><a href="#dom-quictransportstats-timestamp">timestamp</a><span>, in §7.5</span>
@@ -3089,6 +3103,8 @@ use in this specification.</p>
    <dd>Jana Iyengar; Martin Thomson. <a href="https://quicwg.org/base-drafts/draft-ietf-quic-transport.html">QUIC: A UDP-Based Multiplexed and Secure Transport</a>. Internet-Draft. URL: <a href="https://quicwg.org/base-drafts/draft-ietf-quic-transport.html">https://quicwg.org/base-drafts/draft-ietf-quic-transport.html</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-rfc5280">[RFC5280]
+   <dd>D. Cooper; et al. <a href="https://tools.ietf.org/html/rfc5280">Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</a>. May 2008. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc5280">https://tools.ietf.org/html/rfc5280</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-web-transport-http3">[WEB-TRANSPORT-HTTP3]
@@ -3162,7 +3178,7 @@ use in this specification.</p>
 };
 
 <c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportconfiguration" id="ref-for-dictdef-quictransportconfiguration②"><c- g>QuicTransportConfiguration</c-></a> {
-  <c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint②"><c- n>RTCDtlsFingerprint</c-></a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<RTCDtlsFingerprint> " href="#dom-quictransportconfiguration-server_certificates" id="ref-for-dom-quictransportconfiguration-server_certificates②"><c- g>server_certificates</c-></a>;
+  <c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint②"><c- n>RTCDtlsFingerprint</c-></a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<RTCDtlsFingerprint> " href="#dom-quictransportconfiguration-server_certificate_fingerprints" id="ref-for-dom-quictransportconfiguration-server_certificate_fingerprints②"><c- g>server_certificate_fingerprints</c-></a>;
 };
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑦"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
@@ -3220,6 +3236,13 @@ use in this specification.</p>
 <a class="n" data-link-type="idl-name" href="#http3transport" id="ref-for-http3transport③①"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#datagramtransport" id="ref-for-datagramtransport⑤①"><c- n>DatagramTransport</c-></a>;
 <a class="n" data-link-type="idl-name" href="#http3transport" id="ref-for-http3transport④①"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#webtransport" id="ref-for-webtransport⑨①"><c- n>WebTransport</c-></a>;
 </pre>
+  <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
+  <div style="counter-reset:issue">
+   <div class="issue"> Reconsider the time period above.  We want it to be sufficiently large
+that applications using this for ephemeral certificates can do so without
+having to fight the clock skew, but small enough to discourage long-term use
+without key rotation.<a href="#issue-7e6950b7"> ↵ </a></div>
+  </div>
   <aside class="dfn-panel" data-for="unidirectionalstreamstransport">
    <b><a href="#unidirectionalstreamstransport">#unidirectionalstreamstransport</a></b><b>Referenced in:</b>
    <ul>
@@ -3500,10 +3523,16 @@ use in this specification.</p>
     <li><a href="#ref-for-dictdef-quictransportconfiguration①">8.2. Interface Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-quictransportconfiguration-server_certificates">
-   <b><a href="#dom-quictransportconfiguration-server_certificates">#dom-quictransportconfiguration-server_certificates</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-quictransportconfiguration-server_certificate_fingerprints">
+   <b><a href="#dom-quictransportconfiguration-server_certificate_fingerprints">#dom-quictransportconfiguration-server_certificate_fingerprints</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-quictransportconfiguration-server_certificates">8.1. Configuration</a> <a href="#ref-for-dom-quictransportconfiguration-server_certificates①">(2)</a>
+    <li><a href="#ref-for-dom-quictransportconfiguration-server_certificate_fingerprints">8.1. Configuration</a> <a href="#ref-for-dom-quictransportconfiguration-server_certificate_fingerprints①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="custom-certificate-requirements">
+   <b><a href="#custom-certificate-requirements">#custom-certificate-requirements</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-custom-certificate-requirements">8.1. Configuration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-quictransport-quictransport">

--- a/index.html
+++ b/index.html
@@ -1029,7 +1029,7 @@ Possible extra rowspan handling
 		}
 	/* } */
 
-	@supports (display:grid) {
+	@supports (display:grid) and (display:contents) {
 		/* Use #toc over .toc to override non-@supports rules. */
 		#toc {
 			display: grid;
@@ -1167,6 +1167,18 @@ Possible extra rowspan handling
 		margin-left: auto;
 		margin-right: auto;
 	}
+	.overlarge {
+		/* Magic to create good table positioning:
+		   "content column" is 50ems wide at max; less on smaller screens.
+		   Extra space (after ToC + content) is empty on the right.
+
+		   1. When table < content column, centers table in column.
+		   2. When content < table < available, left-aligns.
+		   3. When table > available, fills available + scroll bar.
+		*/ 
+		display: grid;
+		grid-template-columns: minmax(0, 50em);
+	}
 	.overlarge > table {
 		/* limit preferred width of table */
 		max-width: 50em;
@@ -1176,7 +1188,6 @@ Possible extra rowspan handling
 
 	@media (min-width: 55em) {
 		.overlarge {
-			margin-left: calc(13px + 26.5rem - 50vw);
 			margin-right: calc(13px + 26.5rem - 50vw);
 			max-width: none;
 		}
@@ -1184,14 +1195,12 @@ Possible extra rowspan handling
 	@media screen and (min-width: 78em) {
 		body:not(.toc-inline) .overlarge {
 			/* 30.5em body padding 50em content area */
-			margin-left: calc(40em - 50vw) !important;
 			margin-right: calc(40em - 50vw) !important;
 		}
 	}
 	@media screen and (min-width: 90em) {
 		body:not(.toc-inline) .overlarge {
 			/* 4em html margin 30.5em body padding 50em content area */
-			margin-left: 0 !important;
 			margin-right: calc(84.5em - 100vw) !important;
 		}
 	}
@@ -1212,9 +1221,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 670c46b501fc025ae87a3398a195af35379ab37d" name="generator">
+  <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <link href="https://wicg.github.io/web-transport/" rel="canonical">
-  <meta content="c0f6050d16a163e898bb672e596234410b5c4aac" name="document-revision">
+  <meta content="188bd8ebc577e8b380cf4c02dfcfe30f697b25f7" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1472,7 +1481,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">WebTransport</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-12-19">19 December 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-06">6 February 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1486,7 +1495,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2019 the Contributors to the WebTransport Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2020 the Contributors to the WebTransport Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
 A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
    <hr title="Separator for header">
   </div>
@@ -1556,8 +1565,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li>
      <a href="#quic-transport"><span class="secno">8</span> <span class="content"><code>QuicTransport</code> Interface</span></a>
      <ol class="toc">
-      <li><a href="#quic-transport-definition"><span class="secno">8.1</span> <span class="content">Interface Definition</span></a>
-      <li><a href="#quic-transport-methods"><span class="secno">8.2</span> <span class="content">Methods</span></a>
+      <li><a href="#quic-transport-configuration"><span class="secno">8.1</span> <span class="content">Configuration</span></a>
+      <li><a href="#quic-transport-definition"><span class="secno">8.2</span> <span class="content">Interface Definition</span></a>
+      <li><a href="#quic-transport-methods"><span class="secno">8.3</span> <span class="content">Methods</span></a>
      </ol>
     <li>
      <a href="#outgoing-stream"><span class="secno">9</span> <span class="content">Interface Mixin <code>OutgoingStream</code></span></a>
@@ -2010,20 +2020,20 @@ frame.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-quictransportstats"><code>QuicTransportStats</code></dfn> dictionary includes information
 on QUIC connection level stats.</p>
 <pre class="idl highlight def"><c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportstats" id="ref-for-dictdef-quictransportstats"><c- g>QuicTransportStats</c-></a> {
-  <a class="n" data-link-type="idl-name"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-timestamp" id="ref-for-dom-quictransportstats-timestamp"><c- g>timestamp</c-></a>;
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-timestamp" id="ref-for-dom-quictransportstats-timestamp"><c- g>timestamp</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytessent" id="ref-for-dom-quictransportstats-bytessent"><c- g>bytesSent</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetssent" id="ref-for-dom-quictransportstats-packetssent"><c- g>packetsSent</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numoutgoingstreamscreated" id="ref-for-dom-quictransportstats-numoutgoingstreamscreated"><c- g>numOutgoingStreamsCreated</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numincomingstreamscreated" id="ref-for-dom-quictransportstats-numincomingstreamscreated"><c- g>numIncomingStreamsCreated</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long②"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytesreceived" id="ref-for-dom-quictransportstats-bytesreceived"><c- g>bytesReceived</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long③"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetsreceived" id="ref-for-dom-quictransportstats-packetsreceived"><c- g>packetsReceived</c-></a>;
-  <a class="n" data-link-type="idl-name"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrtt" id="ref-for-dom-quictransportstats-minrtt"><c- g>minRtt</c-></a>;
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrtt" id="ref-for-dom-quictransportstats-minrtt"><c- g>minRtt</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numreceiveddatagramsdropped" id="ref-for-dom-quictransportstats-numreceiveddatagramsdropped"><c- g>numReceivedDatagramsDropped</c-></a>;
 };
 </pre>
    <p>The dictionary SHALL have the following attributes:</p>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-timestamp"><code>timestamp</code></dfn>, <span> of type <a data-link-type="idl-name">DOMHighResTimeStamp</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-timestamp"><code>timestamp</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp②">DOMHighResTimeStamp</a></span>
     <dd data-md>
      <p>The <code>timestamp</code> for when the stats are gathered, relative to the
  UNIX epoch (Jan 1, 1970, UTC).</p>
@@ -2048,7 +2058,7 @@ on QUIC connection level stats.</p>
     <dd data-md>
      <p>The number of total packets received on the QUIC connection, including
  packets that were not processable.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-minrtt"><code>minRtt</code></dfn>, <span> of type <a data-link-type="idl-name">DOMHighResTimeStamp</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-minrtt"><code>minRtt</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp③">DOMHighResTimeStamp</a></span>
     <dd data-md>
      <p>The minimum RTT observed on the entire connection.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportStats" data-dfn-type="dict-member" data-export id="dom-quictransportstats-numreceiveddatagramsdropped"><code>numReceivedDatagramsDropped</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤">unsigned long</a></span>
@@ -2061,9 +2071,25 @@ on QUIC connection level stats.</p>
 with unidirectional QUIC streams as defined in <a data-link-type="biblio" href="#biblio-quic-transport">[QUIC-TRANSPORT]</a>. <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream⑨">BidirectionalStream</a></code>s are implemented with bidirectional QUIC streams as
 defined in <a data-link-type="biblio" href="#biblio-quic-transport">[QUIC-TRANSPORT]</a>. Datagrams are implemented with QUIC datagrams as
 defined in <a data-link-type="biblio" href="#biblio-quic-datagram">[QUIC-DATAGRAM]</a>.</p>
-   <h3 class="heading settled" data-level="8.1" id="quic-transport-definition"><span class="secno">8.1. </span><span class="content">Interface Definition</span><a class="self-link" href="#quic-transport-definition"></a></h3>
-<pre class="idl highlight def">[<dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="constructor" data-export data-lt="QuicTransport(url)" id="dom-quictransport-quictransport"><code><c- g>Constructor</c-></code></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport/QuicTransport(url)" data-dfn-type="argument" data-export id="dom-quictransport-quictransport-url-url"><code><c- g>url</c-></code></dfn>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
+   <h3 class="heading settled" data-level="8.1" id="quic-transport-configuration"><span class="secno">8.1. </span><span class="content">Configuration</span><a class="self-link" href="#quic-transport-configuration"></a></h3>
+<pre class="idl highlight def"><c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportconfiguration" id="ref-for-dictdef-quictransportconfiguration"><c- g>QuicTransportConfiguration</c-></a> {
+  <c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint"><c- n>RTCDtlsFingerprint</c-></a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<RTCDtlsFingerprint> " href="#dom-quictransportconfiguration-server_certificates" id="ref-for-dom-quictransportconfiguration-server_certificates"><c- g>server_certificates</c-></a>;
+};
+</pre>
+   <p><dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-quictransportconfiguration"><code>QuicTransportConfiguration</code></dfn> is a dictionary of parameters
+that determine how QuicTransport connection is established and used.</p>
+   <dl>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportConfiguration" data-dfn-type="dict-member" data-export id="dom-quictransportconfiguration-server_certificates"><code>server_certificates</code></dfn>, <span> of type sequence&lt;<a data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint①">RTCDtlsFingerprint</a>></span>
+    <dd data-md>
+     <p>If non-empty, the user agent SHALL deem a server certificate trusted if and
+ only if it matches one of the fingerprints defined in <code class="idl"><a data-link-type="idl" href="#dom-quictransportconfiguration-server_certificates" id="ref-for-dom-quictransportconfiguration-server_certificates①">server_certificates</a></code>.  The user agent SHALL
+ ignore any fingerprint that uses an unknown <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-algorithm" id="ref-for-dom-rtcdtlsfingerprint-algorithm">algorithm</a></code> or has a malformed <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-value" id="ref-for-dom-rtcdtlsfingerprint-value">value</a></code>.  If empty, the user agent
+ SHALL use certificate verification procedures. it would use for normal <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch">fetch</a> operations.</p>
+   </dl>
+   <h3 class="heading settled" data-level="8.2" id="quic-transport-definition"><span class="secno">8.2. </span><span class="content">Interface Definition</span><a class="self-link" href="#quic-transport-definition"></a></h3>
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#quictransport" id="ref-for-quictransport"><c- g>QuicTransport</c-></a> {
+  <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="constructor" data-export data-lt="QuicTransport(url, config)|constructor(url, config)|QuicTransport(url)|constructor(url)" id="dom-quictransport-quictransport"><code><c- g>constructor</c-></code></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport/constructor(url, config), QuicTransport/constructor(url)" data-dfn-type="argument" data-export id="dom-quictransport-constructor-url-config-url"><code><c- g>url</c-></code></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-quictransportconfiguration" id="ref-for-dictdef-quictransportconfiguration①"><c- n>QuicTransportConfiguration</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport/constructor(url, config), QuicTransport/constructor(url)" data-dfn-type="argument" data-export id="dom-quictransport-constructor-url-config-config"><code><c- g>config</c-></code></dfn> = {});
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-quictransportstats" id="ref-for-dictdef-quictransportstats①"><c- n>QuicTransportStats</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-quictransport-getstats" id="ref-for-dom-quictransport-getstats"><c- g>getStats</c-></a>();
 };
 
@@ -2076,7 +2102,7 @@ defined in <a data-link-type="biblio" href="#biblio-quic-datagram">[QUIC-DATAGRA
 agent MUST run the following steps:</p>
    <ol>
     <li data-md>
-     <p>Let <var>parsedURL</var> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url">URL record</a> resulting from <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser">parsing</a> of <code class="idl"><a data-link-type="idl" href="#dom-quictransport-quictransport-url-url" id="ref-for-dom-quictransport-quictransport-url-url">url</a></code>.</p>
+     <p>Let <var>parsedURL</var> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url">URL record</a> resulting from <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser">parsing</a> of <code class="idl"><a data-link-type="idl" href="#dom-quictransport-constructor-url-config-url" id="ref-for-dom-quictransport-constructor-url-config-url">url</a></code>.</p>
     <li data-md>
      <p>If <var>parsedURL</var> is a failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw①">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror" id="ref-for-syntaxerror">SyntaxError</a></code> exception.</p>
     <li data-md>
@@ -2110,7 +2136,9 @@ agent MUST run the following steps:</p>
       <li data-md>
        <p>Let <var>clientOrigin</var> be <var>transport</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a>, <a href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin">serialized</a>.</p>
       <li data-md>
-       <p>Establish a QUIC connection to the address identified by <var>parsedURL</var> following the procedures in <a data-link-type="biblio" href="#biblio-web-transport-quic">[WEB-TRANSPORT-QUIC]</a> section 3 and using <var>clientOrigin</var> as the "origin of the client" referenced in section 3.2.1.</p>
+       <p>Establish a QUIC connection to the address identified by <var>parsedURL</var> following the procedures in <a data-link-type="biblio" href="#biblio-web-transport-quic">[WEB-TRANSPORT-QUIC]</a> section 3 and using <var>clientOrigin</var> as the "origin of the client" referenced in section 3.2.1.
+ While establishing the connection, follow all of the parameters
+ specified in the <code class="idl"><a data-link-type="idl" href="#dom-quictransport-constructor-url-config-config" id="ref-for-dom-quictransport-constructor-url-config-config">config</a></code>.</p>
       <li data-md>
        <p>If the connection fails, set <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-webtransportstate-slot" id="ref-for-dom-quictransport-webtransportstate-slot⑥">[[WebTransportState]]</a></code> internal slot to <code>"failed"</code> and abort these steps.</p>
       <li data-md>
@@ -2119,7 +2147,7 @@ agent MUST run the following steps:</p>
     <li data-md>
      <p>Return <var>transport</var>.</p>
    </ol>
-   <h3 class="heading settled" data-level="8.2" id="quic-transport-methods"><span class="secno">8.2. </span><span class="content">Methods</span><a class="self-link" href="#quic-transport-methods"></a></h3>
+   <h3 class="heading settled" data-level="8.3" id="quic-transport-methods"><span class="secno">8.3. </span><span class="content">Methods</span><a class="self-link" href="#quic-transport-methods"></a></h3>
    <dl>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="method" data-export id="dom-quictransport-getstats"><code>getStats()</code></dfn>
     <dd data-md>
@@ -2625,6 +2653,8 @@ use in this specification.</p>
    <li><a href="#dom-webtransport-closed">closed</a><span>, in §7.1</span>
    <li><a href="#dom-webtransportstate-connected">"connected"</a><span>, in §7.3</span>
    <li><a href="#dom-webtransportstate-connecting">"connecting"</a><span>, in §7.3</span>
+   <li><a href="#dom-quictransport-quictransport">constructor(url)</a><span>, in §8.2</span>
+   <li><a href="#dom-quictransport-quictransport">constructor(url, config)</a><span>, in §8.2</span>
    <li><a href="#dom-bidirectionalstreamstransport-createbidirectionalstream">createBidirectionalStream()</a><span>, in §5.1</span>
    <li><a href="#dom-unidirectionalstreamstransport-createsendstream">createSendStream()</a><span>, in §4.1</span>
    <li><a href="#dom-unidirectionalstreamstransport-createsendstream">createSendStream(parameters)</a><span>, in §4.1</span>
@@ -2636,7 +2666,7 @@ use in this specification.</p>
      <li><a href="#dom-webtransportcloseinfo-errorcode">dict-member for WebTransportCloseInfo</a><span>, in §7.4</span>
     </ul>
    <li><a href="#dom-webtransportstate-failed">"failed"</a><span>, in §7.3</span>
-   <li><a href="#dom-quictransport-getstats">getStats()</a><span>, in §8.2</span>
+   <li><a href="#dom-quictransport-getstats">getStats()</a><span>, in §8.3</span>
    <li><a href="#http3transport">Http3Transport</a><span>, in §14.1</span>
    <li><a href="#dom-http3transport-http3transport">Http3Transport(url)</a><span>, in §14.2</span>
    <li><a href="#immediate-close">Immediate Close</a><span>, in §7.2</span>
@@ -2648,34 +2678,37 @@ use in this specification.</p>
    <li><a href="#dom-quictransportstats-numreceiveddatagramsdropped">numReceivedDatagramsDropped</a><span>, in §7.5</span>
    <li><a href="#dom-webtransport-onstatechange">onstatechange</a><span>, in §7.1</span>
    <li><a href="#outgoingstream">OutgoingStream</a><span>, in §9</span>
-   <li><a href="#dom-quictransport-outgoingstreams-slot">[[OutgoingStreams]]</a><span>, in §8.1</span>
+   <li><a href="#dom-quictransport-outgoingstreams-slot">[[OutgoingStreams]]</a><span>, in §8.2</span>
    <li><a href="#dom-quictransportstats-packetsreceived">packetsReceived</a><span>, in §7.5</span>
    <li><a href="#dom-quictransportstats-packetssent">packetsSent</a><span>, in §7.5</span>
    <li><a href="#quictransport">QuicTransport</a><span>, in §8</span>
+   <li><a href="#dictdef-quictransportconfiguration">QuicTransportConfiguration</a><span>, in §8.1</span>
    <li><a href="#dictdef-quictransportstats">QuicTransportStats</a><span>, in §7.5</span>
-   <li><a href="#dom-quictransport-quictransport">QuicTransport(url)</a><span>, in §8.1</span>
+   <li><a href="#dom-quictransport-quictransport">QuicTransport(url)</a><span>, in §8.2</span>
+   <li><a href="#dom-quictransport-quictransport">QuicTransport(url, config)</a><span>, in §8.2</span>
    <li><a href="#dom-incomingstream-readable">readable</a><span>, in §10.2</span>
    <li><a href="#dom-incomingstream-readable-slot">[[Readable]]</a><span>, in §10.1</span>
    <li><a href="#dom-incomingstream-readingaborted">readingAborted</a><span>, in §10.2</span>
    <li><a href="#dom-webtransportcloseinfo-reason">reason</a><span>, in §7.4</span>
    <li><a href="#dom-bidirectionalstreamstransport-receivebidirectionalstreams">receiveBidirectionalStreams()</a><span>, in §5.1</span>
    <li><a href="#dom-datagramtransport-receivedatagrams">receiveDatagrams()</a><span>, in §6.2</span>
-   <li><a href="#dom-quictransport-receivedbidirectionalstreams-slot">[[ReceivedBidirectionalStreams]]</a><span>, in §8.1</span>
-   <li><a href="#dom-quictransport-receiveddatagrams-slot">[[ReceivedDatagrams]]</a><span>, in §8.1</span>
-   <li><a href="#dom-quictransport-receivedstreams-slot">[[ReceivedStreams]]</a><span>, in §8.1</span>
+   <li><a href="#dom-quictransport-receivedbidirectionalstreams-slot">[[ReceivedBidirectionalStreams]]</a><span>, in §8.2</span>
+   <li><a href="#dom-quictransport-receiveddatagrams-slot">[[ReceivedDatagrams]]</a><span>, in §8.2</span>
+   <li><a href="#dom-quictransport-receivedstreams-slot">[[ReceivedStreams]]</a><span>, in §8.2</span>
    <li><a href="#receivestream">ReceiveStream</a><span>, in §13</span>
    <li><a href="#dom-unidirectionalstreamstransport-receivestreams">receiveStreams()</a><span>, in §4.1</span>
    <li><a href="#dom-datagramtransport-senddatagrams">sendDatagrams()</a><span>, in §6.2</span>
    <li><a href="#sendstream">SendStream</a><span>, in §12</span>
    <li><a href="#dictdef-sendstreamparameters">SendStreamParameters</a><span>, in §4.3</span>
-   <li><a href="#dom-quictransport-sentdatagrams-slot">[[SentDatagrams]]</a><span>, in §8.1</span>
+   <li><a href="#dom-quictransport-sentdatagrams-slot">[[SentDatagrams]]</a><span>, in §8.2</span>
+   <li><a href="#dom-quictransportconfiguration-server_certificates">server_certificates</a><span>, in §8.1</span>
    <li><a href="#dom-webtransport-state">state</a><span>, in §7.1</span>
    <li><a href="#dictdef-streamabortinfo">StreamAbortInfo</a><span>, in §9.4</span>
    <li><a href="#dom-quictransportstats-timestamp">timestamp</a><span>, in §7.5</span>
    <li><a href="#unidirectionalstreamstransport">UnidirectionalStreamsTransport</a><span>, in §4</span>
    <li><a href="#webtransport">WebTransport</a><span>, in §7</span>
    <li><a href="#dictdef-webtransportcloseinfo">WebTransportCloseInfo</a><span>, in §7.4</span>
-   <li><a href="#dom-quictransport-webtransportstate-slot">[[WebTransportState]]</a><span>, in §8.1</span>
+   <li><a href="#dom-quictransport-webtransportstate-slot">[[WebTransportState]]</a><span>, in §8.2</span>
    <li><a href="#enumdef-webtransportstate">WebTransportState</a><span>, in §7.3</span>
    <li><a href="#dom-outgoingstream-writable-slot">[[Writable]]</a><span>, in §9.1</span>
    <li><a href="#dom-outgoingstream-writable">writable</a><span>, in §9.2</span>
@@ -2742,6 +2775,18 @@ use in this specification.</p>
     <li><a href="#ref-for-sec-promise-objects①⑨">10.2. Attributes</a> <a href="#ref-for-sec-promise-objects②⓪">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-fetch">
+   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-fetch">8.1. Configuration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
+   <a href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp">https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-domhighrestimestamp">7.5. QuicTransportStats Dictionary</a> <a href="#ref-for-dom-domhighrestimestamp①">(2)</a> <a href="#ref-for-dom-domhighrestimestamp②">(3)</a> <a href="#ref-for-dom-domhighrestimestamp③">(4)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-errorevent">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">https://html.spec.whatwg.org/multipage/webappapis.html#errorevent</a><b>Referenced in:</b>
    <ul>
@@ -2777,7 +2822,7 @@ use in this specification.</p>
   <aside class="dfn-panel" data-for="term-for-concept-origin">
    <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">https://html.spec.whatwg.org/multipage/origin.html#concept-origin</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-origin">8.1. Interface Definition</a>
+    <li><a href="#ref-for-concept-origin">8.2. Interface Definition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-queue-a-task">
@@ -2789,31 +2834,31 @@ use in this specification.</p>
   <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-relevant-settings-object">8.1. Interface Definition</a>
+    <li><a href="#ref-for-relevant-settings-object">8.2. Interface Definition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
    <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-fragment">8.1. Interface Definition</a>
+    <li><a href="#ref-for-concept-url-fragment">8.2. Interface Definition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
    <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-scheme">8.1. Interface Definition</a>
+    <li><a href="#ref-for-concept-url-scheme">8.2. Interface Definition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-parser">
    <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-parser">8.1. Interface Definition</a>
+    <li><a href="#ref-for-concept-url-parser">8.2. Interface Definition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url">
    <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url">8.1. Interface Definition</a>
+    <li><a href="#ref-for-concept-url">8.2. Interface Definition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
@@ -2832,7 +2877,7 @@ use in this specification.</p>
   <aside class="dfn-panel" data-for="term-for-Exposed">
    <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Exposed">8.1. Interface Definition</a>
+    <li><a href="#ref-for-Exposed">8.2. Interface Definition</a>
     <li><a href="#ref-for-Exposed①">9. Interface Mixin OutgoingStream</a>
     <li><a href="#ref-for-Exposed②">10. Interface Mixin IncomingStream</a>
     <li><a href="#ref-for-Exposed③">11. Interface BidirectionalStream</a>
@@ -2851,19 +2896,19 @@ use in this specification.</p>
   <aside class="dfn-panel" data-for="term-for-syntaxerror">
    <a href="https://heycam.github.io/webidl/#syntaxerror">https://heycam.github.io/webidl/#syntaxerror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-syntaxerror">8.1. Interface Definition</a> <a href="#ref-for-syntaxerror①">(2)</a> <a href="#ref-for-syntaxerror②">(3)</a>
+    <li><a href="#ref-for-syntaxerror">8.2. Interface Definition</a> <a href="#ref-for-syntaxerror①">(2)</a> <a href="#ref-for-syntaxerror②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-USVString">
    <a href="https://heycam.github.io/webidl/#idl-USVString">https://heycam.github.io/webidl/#idl-USVString</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-USVString">8.1. Interface Definition</a>
+    <li><a href="#ref-for-idl-USVString">8.2. Interface Definition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
    <a href="https://heycam.github.io/webidl/#idl-Uint8Array">https://heycam.github.io/webidl/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-Uint8Array">8.1. Interface Definition</a> <a href="#ref-for-idl-Uint8Array①">(2)</a>
+    <li><a href="#ref-for-idl-Uint8Array">8.2. Interface Definition</a> <a href="#ref-for-idl-Uint8Array①">(2)</a>
     <li><a href="#ref-for-idl-Uint8Array②">14.2.1. Constructors</a> <a href="#ref-for-idl-Uint8Array③">(2)</a>
    </ul>
   </aside>
@@ -2877,7 +2922,7 @@ use in this specification.</p>
    <a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3. Terminology</a>
-    <li><a href="#ref-for-dfn-throw①">8.1. Interface Definition</a> <a href="#ref-for-dfn-throw②">(2)</a> <a href="#ref-for-dfn-throw③">(3)</a>
+    <li><a href="#ref-for-dfn-throw①">8.2. Interface Definition</a> <a href="#ref-for-dfn-throw②">(2)</a> <a href="#ref-for-dfn-throw③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
@@ -2901,6 +2946,24 @@ use in this specification.</p>
     <li><a href="#ref-for-idl-unsigned-short④">9.4. StreamAbortInfo Dictionary</a> <a href="#ref-for-idl-unsigned-short⑤">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint">
+   <a href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint">https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-rtcdtlsfingerprint">8.1. Configuration</a> <a href="#ref-for-dom-rtcdtlsfingerprint①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint-algorithm">
+   <a href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-algorithm">https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-algorithm</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-rtcdtlsfingerprint-algorithm">8.1. Configuration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint-value">
+   <a href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-value">https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-value</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-rtcdtlsfingerprint-value">8.1. Configuration</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-rs-class">
    <a href="https://streams.spec.whatwg.org/#rs-class">https://streams.spec.whatwg.org/#rs-class</a><b>Referenced in:</b>
    <ul>
@@ -2911,7 +2974,7 @@ use in this specification.</p>
     <li><a href="#ref-for-rs-class④">5.1. Methods</a>
     <li><a href="#ref-for-rs-class⑤">6. DatagramTransport Mixin</a>
     <li><a href="#ref-for-rs-class⑥">7.3. WebTransportState Enum</a> <a href="#ref-for-rs-class⑦">(2)</a> <a href="#ref-for-rs-class⑧">(3)</a> <a href="#ref-for-rs-class⑨">(4)</a>
-    <li><a href="#ref-for-rs-class①⓪">8.1. Interface Definition</a> <a href="#ref-for-rs-class①①">(2)</a> <a href="#ref-for-rs-class①②">(3)</a>
+    <li><a href="#ref-for-rs-class①⓪">8.2. Interface Definition</a> <a href="#ref-for-rs-class①①">(2)</a> <a href="#ref-for-rs-class①②">(3)</a>
     <li><a href="#ref-for-rs-class①③">10. Interface Mixin IncomingStream</a>
     <li><a href="#ref-for-rs-class①④">10.1. Overview</a>
     <li><a href="#ref-for-rs-class①⑤">10.2. Attributes</a> <a href="#ref-for-rs-class①⑥">(2)</a>
@@ -2924,7 +2987,7 @@ use in this specification.</p>
     <li><a href="#ref-for-ws-class">3. Terminology</a>
     <li><a href="#ref-for-ws-class①">6. DatagramTransport Mixin</a>
     <li><a href="#ref-for-ws-class②">6.2. Methods</a>
-    <li><a href="#ref-for-ws-class③">8.1. Interface Definition</a>
+    <li><a href="#ref-for-ws-class③">8.2. Interface Definition</a>
     <li><a href="#ref-for-ws-class④">9. Interface Mixin OutgoingStream</a>
     <li><a href="#ref-for-ws-class⑤">9.1. Overview</a>
     <li><a href="#ref-for-ws-class⑥">9.2. Attributes</a> <a href="#ref-for-ws-class⑦">(2)</a>
@@ -2946,6 +3009,16 @@ use in this specification.</p>
      <li><span class="dfn-paneled" id="term-for-sec-promise-objects②" style="color:initial">rejected</span>
      <li><span class="dfn-paneled" id="term-for-sec-promise-objects③" style="color:initial">resolved</span>
      <li><span class="dfn-paneled" id="term-for-sec-promise-objects④" style="color:initial">settled</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[FETCH]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-concept-fetch" style="color:initial">fetch</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[hr-time-2]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-dom-domhighrestimestamp" style="color:initial">DOMHighResTimeStamp</span>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
@@ -2984,6 +3057,13 @@ use in this specification.</p>
      <li><span class="dfn-paneled" id="term-for-idl-unsigned-short" style="color:initial">unsigned short</span>
     </ul>
    <li>
+    <a data-link-type="biblio">[webrtc-1]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-dom-rtcdtlsfingerprint" style="color:initial">RTCDtlsFingerprint</span>
+     <li><span class="dfn-paneled" id="term-for-dom-rtcdtlsfingerprint-algorithm" style="color:initial">algorithm</span>
+     <li><span class="dfn-paneled" id="term-for-dom-rtcdtlsfingerprint-value" style="color:initial">value</span>
+    </ul>
+   <li>
     <a data-link-type="biblio">[WHATWG-STREAMS]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-rs-class" style="color:initial">ReadableStream</span>
@@ -2997,6 +3077,10 @@ use in this specification.</p>
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-ecmascript-60">[ECMASCRIPT-6.0]
    <dd>Allen Wirfs-Brock. <a href="http://www.ecma-international.org/ecma-262/6.0/index.html">ECMA-262 6th Edition, The ECMAScript 2015 Language Specification</a>. June 2015. Standard. URL: <a href="http://www.ecma-international.org/ecma-262/6.0/index.html">http://www.ecma-international.org/ecma-262/6.0/index.html</a>
+   <dt id="biblio-fetch">[FETCH]
+   <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dt id="biblio-hr-time-2">[HR-TIME-2]
+   <dd>Ilya Grigorik. <a href="https://www.w3.org/TR/hr-time-2/">High Resolution Time Level 2</a>. 21 November 2019. REC. URL: <a href="https://www.w3.org/TR/hr-time-2/">https://www.w3.org/TR/hr-time-2/</a>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-quic-datagram">[QUIC-DATAGRAM]
@@ -3014,7 +3098,9 @@ use in this specification.</p>
    <dt id="biblio-web-transport-quic">[WEB-TRANSPORT-QUIC]
    <dd>Victor Vasiliev. <a href="https://tools.ietf.org/html/draft-vvv-webtransport-quic">WebTransport over QUIC</a>. Internet-Draft. URL: <a href="https://tools.ietf.org/html/draft-vvv-webtransport-quic">https://tools.ietf.org/html/draft-vvv-webtransport-quic</a>
    <dt id="biblio-webidl">[WEBIDL]
-   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dt id="biblio-webrtc-1">[WEBRTC-1]
+   <dd>WebRTC 1.0: Real-time Communication Between Browsers URL: <a href="https://www.w3.org/TR/webrtc/">https://www.w3.org/TR/webrtc/</a>
    <dt id="biblio-whatwg-streams">[WHATWG-STREAMS]
    <dd>Adam Rice; Domenic Denicola; 吉野剛史 (Takeshi Yoshino). <a href="https://streams.spec.whatwg.org/">Streams Standard</a>. Living Standard. URL: <a href="https://streams.spec.whatwg.org/">https://streams.spec.whatwg.org/</a>
   </dl>
@@ -3064,19 +3150,24 @@ use in this specification.</p>
 };
 
 <c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportstats" id="ref-for-dictdef-quictransportstats③"><c- g>QuicTransportStats</c-></a> {
-  <a class="n" data-link-type="idl-name"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-timestamp" id="ref-for-dom-quictransportstats-timestamp①"><c- g>timestamp</c-></a>;
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp④"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-timestamp" id="ref-for-dom-quictransportstats-timestamp①"><c- g>timestamp</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑧"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytessent" id="ref-for-dom-quictransportstats-bytessent①"><c- g>bytesSent</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetssent" id="ref-for-dom-quictransportstats-packetssent①"><c- g>packetsSent</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numoutgoingstreamscreated" id="ref-for-dom-quictransportstats-numoutgoingstreamscreated①"><c- g>numOutgoingStreamsCreated</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numincomingstreamscreated" id="ref-for-dom-quictransportstats-numincomingstreamscreated①"><c- g>numIncomingStreamsCreated</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long②①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytesreceived" id="ref-for-dom-quictransportstats-bytesreceived①"><c- g>bytesReceived</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long③①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetsreceived" id="ref-for-dom-quictransportstats-packetsreceived①"><c- g>packetsReceived</c-></a>;
-  <a class="n" data-link-type="idl-name"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrtt" id="ref-for-dom-quictransportstats-minrtt①"><c- g>minRtt</c-></a>;
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrtt" id="ref-for-dom-quictransportstats-minrtt①"><c- g>minRtt</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numreceiveddatagramsdropped" id="ref-for-dom-quictransportstats-numreceiveddatagramsdropped①"><c- g>numReceivedDatagramsDropped</c-></a>;
 };
 
-[<a href="#dom-quictransport-quictransport"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><c- b>USVString</c-></a> <a href="#dom-quictransport-quictransport-url-url"><code><c- g>url</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑦"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
+<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportconfiguration" id="ref-for-dictdef-quictransportconfiguration②"><c- g>QuicTransportConfiguration</c-></a> {
+  <c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint②"><c- n>RTCDtlsFingerprint</c-></a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<RTCDtlsFingerprint> " href="#dom-quictransportconfiguration-server_certificates" id="ref-for-dom-quictransportconfiguration-server_certificates②"><c- g>server_certificates</c-></a>;
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑦"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#quictransport" id="ref-for-quictransport⑧"><c- g>QuicTransport</c-></a> {
+  <a href="#dom-quictransport-quictransport"><code><c- g>constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><c- b>USVString</c-></a> <a href="#dom-quictransport-constructor-url-config-url"><code><c- g>url</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-quictransportconfiguration" id="ref-for-dictdef-quictransportconfiguration①①"><c- n>QuicTransportConfiguration</c-></a> <a href="#dom-quictransport-constructor-url-config-config"><code><c- g>config</c-></code></a> = {});
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-quictransportstats" id="ref-for-dictdef-quictransportstats①①"><c- n>QuicTransportStats</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-quictransport-getstats" id="ref-for-dom-quictransport-getstats①"><c- g>getStats</c-></a>();
 };
 
@@ -3135,7 +3226,7 @@ use in this specification.</p>
     <li><a href="#ref-for-unidirectionalstreamstransport">4. UnidirectionalStreamsTransport Mixin</a>
     <li><a href="#ref-for-unidirectionalstreamstransport①">4.2.1. Add SendStream to UnidirectionalStreamsTransport</a> <a href="#ref-for-unidirectionalstreamstransport②">(2)</a>
     <li><a href="#ref-for-unidirectionalstreamstransport③">8. QuicTransport Interface</a>
-    <li><a href="#ref-for-unidirectionalstreamstransport④">8.1. Interface Definition</a>
+    <li><a href="#ref-for-unidirectionalstreamstransport④">8.2. Interface Definition</a>
     <li><a href="#ref-for-unidirectionalstreamstransport⑤">14.1. Overview</a>
     <li><a href="#ref-for-unidirectionalstreamstransport⑥">14.2. Interface Definition</a>
    </ul>
@@ -3172,7 +3263,7 @@ use in this specification.</p>
     <li><a href="#ref-for-bidirectionalstreamstransport①">5.1. Methods</a>
     <li><a href="#ref-for-bidirectionalstreamstransport②">5.2.1. Add BidirectionalStream to BidirectionalStreamsTransport</a> <a href="#ref-for-bidirectionalstreamstransport③">(2)</a>
     <li><a href="#ref-for-bidirectionalstreamstransport④">8. QuicTransport Interface</a>
-    <li><a href="#ref-for-bidirectionalstreamstransport⑤">8.1. Interface Definition</a>
+    <li><a href="#ref-for-bidirectionalstreamstransport⑤">8.2. Interface Definition</a>
     <li><a href="#ref-for-bidirectionalstreamstransport⑥">14.1. Overview</a>
     <li><a href="#ref-for-bidirectionalstreamstransport⑦">14.2. Interface Definition</a>
    </ul>
@@ -3202,7 +3293,7 @@ use in this specification.</p>
     <li><a href="#ref-for-datagramtransport">6. DatagramTransport Mixin</a>
     <li><a href="#ref-for-datagramtransport①">6.2. Methods</a>
     <li><a href="#ref-for-datagramtransport②">8. QuicTransport Interface</a>
-    <li><a href="#ref-for-datagramtransport③">8.1. Interface Definition</a>
+    <li><a href="#ref-for-datagramtransport③">8.2. Interface Definition</a>
     <li><a href="#ref-for-datagramtransport④">14.1. Overview</a>
     <li><a href="#ref-for-datagramtransport⑤">14.2. Interface Definition</a>
     <li><a href="#ref-for-datagramtransport⑥">16.1. Sending a buffer of datagrams</a>
@@ -3236,7 +3327,7 @@ use in this specification.</p>
    <ul>
     <li><a href="#ref-for-webtransport">7.3. WebTransportState Enum</a> <a href="#ref-for-webtransport①">(2)</a>
     <li><a href="#ref-for-webtransport②">7.4. WebTransportCloseInfo Dictionary</a> <a href="#ref-for-webtransport③">(2)</a>
-    <li><a href="#ref-for-webtransport④">8.1. Interface Definition</a>
+    <li><a href="#ref-for-webtransport④">8.2. Interface Definition</a>
     <li><a href="#ref-for-webtransport⑤">9.2. Attributes</a>
     <li><a href="#ref-for-webtransport⑥">9.3. Methods</a>
     <li><a href="#ref-for-webtransport⑦">10.2. Attributes</a>
@@ -3336,8 +3427,8 @@ use in this specification.</p>
    <b><a href="#dictdef-quictransportstats">#dictdef-quictransportstats</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-quictransportstats">7.5. QuicTransportStats Dictionary</a>
-    <li><a href="#ref-for-dictdef-quictransportstats①">8.1. Interface Definition</a>
-    <li><a href="#ref-for-dictdef-quictransportstats②">8.2. Methods</a>
+    <li><a href="#ref-for-dictdef-quictransportstats①">8.2. Interface Definition</a>
+    <li><a href="#ref-for-dictdef-quictransportstats②">8.3. Methods</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-quictransportstats-timestamp">
@@ -3397,21 +3488,40 @@ use in this specification.</p>
   <aside class="dfn-panel" data-for="quictransport">
    <b><a href="#quictransport">#quictransport</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-quictransport">8.1. Interface Definition</a> <a href="#ref-for-quictransport①">(2)</a> <a href="#ref-for-quictransport②">(3)</a> <a href="#ref-for-quictransport③">(4)</a> <a href="#ref-for-quictransport④">(5)</a> <a href="#ref-for-quictransport⑤">(6)</a>
-    <li><a href="#ref-for-quictransport⑥">8.2. Methods</a>
+    <li><a href="#ref-for-quictransport">8.2. Interface Definition</a> <a href="#ref-for-quictransport①">(2)</a> <a href="#ref-for-quictransport②">(3)</a> <a href="#ref-for-quictransport③">(4)</a> <a href="#ref-for-quictransport④">(5)</a> <a href="#ref-for-quictransport⑤">(6)</a>
+    <li><a href="#ref-for-quictransport⑥">8.3. Methods</a>
     <li><a href="#ref-for-quictransport⑦">17. Acknowledgements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-quictransportconfiguration">
+   <b><a href="#dictdef-quictransportconfiguration">#dictdef-quictransportconfiguration</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-quictransportconfiguration">8.1. Configuration</a>
+    <li><a href="#ref-for-dictdef-quictransportconfiguration①">8.2. Interface Definition</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-quictransportconfiguration-server_certificates">
+   <b><a href="#dom-quictransportconfiguration-server_certificates">#dom-quictransportconfiguration-server_certificates</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-quictransportconfiguration-server_certificates">8.1. Configuration</a> <a href="#ref-for-dom-quictransportconfiguration-server_certificates①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-quictransport-quictransport">
    <b><a href="#dom-quictransport-quictransport">#dom-quictransport-quictransport</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-quictransport-quictransport">8.1. Interface Definition</a>
+    <li><a href="#ref-for-dom-quictransport-quictransport">8.2. Interface Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-quictransport-quictransport-url-url">
-   <b><a href="#dom-quictransport-quictransport-url-url">#dom-quictransport-quictransport-url-url</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-quictransport-constructor-url-config-url">
+   <b><a href="#dom-quictransport-constructor-url-config-url">#dom-quictransport-constructor-url-config-url</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-quictransport-quictransport-url-url">8.1. Interface Definition</a>
+    <li><a href="#ref-for-dom-quictransport-constructor-url-config-url">8.2. Interface Definition</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-quictransport-constructor-url-config-config">
+   <b><a href="#dom-quictransport-constructor-url-config-config">#dom-quictransport-constructor-url-config-config</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-quictransport-constructor-url-config-config">8.2. Interface Definition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-quictransport-outgoingstreams-slot">
@@ -3448,7 +3558,7 @@ use in this specification.</p>
     <li><a href="#ref-for-dom-quictransport-webtransportstate-slot">7.1. Attributes</a> <a href="#ref-for-dom-quictransport-webtransportstate-slot①">(2)</a>
     <li><a href="#ref-for-dom-quictransport-webtransportstate-slot②">7.2. Methods</a> <a href="#ref-for-dom-quictransport-webtransportstate-slot③">(2)</a>
     <li><a href="#ref-for-dom-quictransport-webtransportstate-slot④">7.3. WebTransportState Enum</a> <a href="#ref-for-dom-quictransport-webtransportstate-slot⑤">(2)</a>
-    <li><a href="#ref-for-dom-quictransport-webtransportstate-slot⑥">8.1. Interface Definition</a> <a href="#ref-for-dom-quictransport-webtransportstate-slot⑦">(2)</a>
+    <li><a href="#ref-for-dom-quictransport-webtransportstate-slot⑥">8.2. Interface Definition</a> <a href="#ref-for-dom-quictransport-webtransportstate-slot⑦">(2)</a>
     <li><a href="#ref-for-dom-quictransport-webtransportstate-slot⑧">14.2.1. Constructors</a> <a href="#ref-for-dom-quictransport-webtransportstate-slot⑨">(2)</a> <a href="#ref-for-dom-quictransport-webtransportstate-slot①⓪">(3)</a>
    </ul>
   </aside>
@@ -3469,14 +3579,14 @@ use in this specification.</p>
   <aside class="dfn-panel" data-for="dom-quictransport-getstats">
    <b><a href="#dom-quictransport-getstats">#dom-quictransport-getstats</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-quictransport-getstats">8.1. Interface Definition</a>
+    <li><a href="#ref-for-dom-quictransport-getstats">8.2. Interface Definition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="outgoingstream">
    <b><a href="#outgoingstream">#outgoingstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outgoingstream">7.3. WebTransportState Enum</a> <a href="#ref-for-outgoingstream①">(2)</a> <a href="#ref-for-outgoingstream②">(3)</a>
-    <li><a href="#ref-for-outgoingstream③">8.1. Interface Definition</a>
+    <li><a href="#ref-for-outgoingstream③">8.2. Interface Definition</a>
     <li><a href="#ref-for-outgoingstream④">9. Interface Mixin OutgoingStream</a>
     <li><a href="#ref-for-outgoingstream⑤">9.1. Overview</a> <a href="#ref-for-outgoingstream⑥">(2)</a>
     <li><a href="#ref-for-outgoingstream⑦">9.2. Attributes</a> <a href="#ref-for-outgoingstream⑧">(2)</a>
@@ -3532,7 +3642,7 @@ use in this specification.</p>
    <b><a href="#incomingstream">#incomingstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-incomingstream">4.1. Methods</a>
-    <li><a href="#ref-for-incomingstream①">8.1. Interface Definition</a> <a href="#ref-for-incomingstream②">(2)</a>
+    <li><a href="#ref-for-incomingstream①">8.2. Interface Definition</a> <a href="#ref-for-incomingstream②">(2)</a>
     <li><a href="#ref-for-incomingstream③">10. Interface Mixin IncomingStream</a>
     <li><a href="#ref-for-incomingstream④">10.1. Overview</a> <a href="#ref-for-incomingstream⑤">(2)</a>
     <li><a href="#ref-for-incomingstream⑥">10.2. Attributes</a> <a href="#ref-for-incomingstream⑦">(2)</a> <a href="#ref-for-incomingstream⑧">(3)</a>

--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version b43aa594f5014ff14748da1aace9afaa73d2b3e6" name="generator">
   <link href="https://wicg.github.io/web-transport/" rel="canonical">
-  <meta content="950f4f5c533cd84c8634437089c769ee67fc9a40" name="document-revision">
+  <meta content="53423d3ad5ce2ae7dfc36dba521d7ae078eb4abd" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -2086,11 +2086,41 @@ that determine how QuicTransport connection is established and used.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportConfiguration" data-dfn-type="dict-member" data-export id="dom-quictransportconfiguration-server_certificate_fingerprints"><code>server_certificate_fingerprints</code></dfn>, <span> of type sequence&lt;<a data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint①">RTCDtlsFingerprint</a>></span>
     <dd data-md>
      <p>If non-empty, the user agent SHALL deem a server certificate trusted if and
- only if it matches one of the fingerprints defined in <code class="idl"><a data-link-type="idl" href="#dom-quictransportconfiguration-server_certificate_fingerprints" id="ref-for-dom-quictransportconfiguration-server_certificate_fingerprints①">server_certificate_fingerprints</a></code> and satisfies <a data-link-type="dfn" href="#custom-certificate-requirements" id="ref-for-custom-certificate-requirements">custom certificate requirements</a>.  The user agent SHALL ignore any
+ only if it can successfully <a data-link-type="dfn" href="#verify-a-certificate-fingerprint" id="ref-for-verify-a-certificate-fingerprint">verify a certificate fingerprint</a> against <code class="idl"><a data-link-type="idl" href="#dom-quictransportconfiguration-server_certificate_fingerprints" id="ref-for-dom-quictransportconfiguration-server_certificate_fingerprints①">server_certificate_fingerprints</a></code> and satisfies <a data-link-type="dfn" href="#custom-certificate-requirements" id="ref-for-custom-certificate-requirements">custom certificate requirements</a>.  The user agent SHALL ignore any
  fingerprint that uses an unknown <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-algorithm" id="ref-for-dom-rtcdtlsfingerprint-algorithm">algorithm</a></code> or has a
  malformed <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-value" id="ref-for-dom-rtcdtlsfingerprint-value">value</a></code>.  If empty, the user agent SHALL use
  certificate verification procedures it would use for normal <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch">fetch</a> operations.</p>
    </dl>
+   <div class="algorithm" data-algorithm="compute a certificate fingerprint">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="compute-a-certificate-fingerprint">compute a certificate fingerprint</dfn>, do the following: 
+    <ol>
+     <li data-md>
+      <p>Let <var>cert</var> be the input certificate, represented as a DER encoding of
+ Certificate message defined in <a data-link-type="biblio" href="#biblio-rfc5280">[RFC5280]</a>.</p>
+     <li data-md>
+      <p>Compute the SHA-256 hash of <var>cert</var>.  Format it as <code>fingerprint</code> BNF
+ rule described in Section 5 of <a data-link-type="biblio" href="#biblio-rfc8122">[RFC8122]</a>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="verify a certificate fingerprint">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="verify-a-certificate-fingerprint">verify a certificate fingerprint</dfn>, do the following: 
+    <ol>
+     <li data-md>
+      <p>Let <var>fprs</var> be the input array of fingerprints.</p>
+     <li data-md>
+      <p>Let <var>ref_fpr</var> be the <a data-link-type="dfn" href="#compute-a-certificate-fingerprint" id="ref-for-compute-a-certificate-fingerprint">computed
+ fingerprint</a> of the input certificate.</p>
+     <li data-md>
+      <p>For every fingerprint <var>fpr</var> in <var>fprs</var>:</p>
+      <ol>
+       <li data-md>
+        <p>If <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-algorithm" id="ref-for-dom-rtcdtlsfingerprint-algorithm①">algorithm</a></code> of <var>fpr</var> is equal to "sha-256", and <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-value" id="ref-for-dom-rtcdtlsfingerprint-value①">value</a></code> of <var>fpr</var> is equal to <var>ref_fpr</var>, the
+  certificate is valid.  Return true.</p>
+      </ol>
+     <li data-md>
+      <p>Return false.</p>
+    </ol>
+   </div>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="custom-certificate-requirements">custom certificate requirements</dfn> are as follows: the certificate
 MUST be an X.509v3 certificate as defined in <a data-link-type="biblio" href="#biblio-rfc5280">[RFC5280]</a>, the current time
 MUST be within the validity period of the certificate as defined in Section
@@ -2667,6 +2697,7 @@ use in this specification.</p>
    <li><a href="#dom-webtransport-close">close(closeInfo)</a><span>, in §7.2</span>
    <li><a href="#dom-webtransportstate-closed">"closed"</a><span>, in §7.3</span>
    <li><a href="#dom-webtransport-closed">closed</a><span>, in §7.1</span>
+   <li><a href="#compute-a-certificate-fingerprint">compute a certificate fingerprint</a><span>, in §8.1</span>
    <li><a href="#dom-webtransportstate-connected">"connected"</a><span>, in §7.3</span>
    <li><a href="#dom-webtransportstate-connecting">"connecting"</a><span>, in §7.3</span>
    <li>
@@ -2728,6 +2759,7 @@ use in this specification.</p>
    <li><a href="#dictdef-streamabortinfo">StreamAbortInfo</a><span>, in §9.4</span>
    <li><a href="#dom-quictransportstats-timestamp">timestamp</a><span>, in §7.5</span>
    <li><a href="#unidirectionalstreamstransport">UnidirectionalStreamsTransport</a><span>, in §4</span>
+   <li><a href="#verify-a-certificate-fingerprint">verify a certificate fingerprint</a><span>, in §8.1</span>
    <li><a href="#webtransport">WebTransport</a><span>, in §7</span>
    <li><a href="#dictdef-webtransportcloseinfo">WebTransportCloseInfo</a><span>, in §7.4</span>
    <li><a href="#dom-quictransport-webtransportstate-slot">[[WebTransportState]]</a><span>, in §8.2</span>
@@ -2977,13 +3009,13 @@ use in this specification.</p>
   <aside class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint-algorithm">
    <a href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-algorithm">https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-algorithm</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-rtcdtlsfingerprint-algorithm">8.1. Configuration</a>
+    <li><a href="#ref-for-dom-rtcdtlsfingerprint-algorithm">8.1. Configuration</a> <a href="#ref-for-dom-rtcdtlsfingerprint-algorithm①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint-value">
    <a href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-value">https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-value</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-rtcdtlsfingerprint-value">8.1. Configuration</a>
+    <li><a href="#ref-for-dom-rtcdtlsfingerprint-value">8.1. Configuration</a> <a href="#ref-for-dom-rtcdtlsfingerprint-value①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-rs-class">
@@ -3113,6 +3145,8 @@ use in this specification.</p>
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-rfc5280">[RFC5280]
    <dd>D. Cooper; et al. <a href="https://tools.ietf.org/html/rfc5280">Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</a>. May 2008. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc5280">https://tools.ietf.org/html/rfc5280</a>
+   <dt id="biblio-rfc8122">[RFC8122]
+   <dd>J. Lennox; C. Holmberg. <a href="https://tools.ietf.org/html/rfc8122">Connection-Oriented Media Transport over the Transport Layer Security (TLS) Protocol in the Session Description Protocol (SDP)</a>. March 2017. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc8122">https://tools.ietf.org/html/rfc8122</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-web-transport-http3">[WEB-TRANSPORT-HTTP3]
@@ -3538,6 +3572,18 @@ without key rotation.<a href="#issue-7e6950b7"> ↵ </a></div>
    <b><a href="#dom-quictransportconfiguration-server_certificate_fingerprints">#dom-quictransportconfiguration-server_certificate_fingerprints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-quictransportconfiguration-server_certificate_fingerprints">8.1. Configuration</a> <a href="#ref-for-dom-quictransportconfiguration-server_certificate_fingerprints①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="compute-a-certificate-fingerprint">
+   <b><a href="#compute-a-certificate-fingerprint">#compute-a-certificate-fingerprint</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-compute-a-certificate-fingerprint">8.1. Configuration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="verify-a-certificate-fingerprint">
+   <b><a href="#verify-a-certificate-fingerprint">#verify-a-certificate-fingerprint</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-verify-a-certificate-fingerprint">8.1. Configuration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="custom-certificate-requirements">


### PR DESCRIPTION
Fixes #18.