### PR TITLE
Add an example for receiving from ReceiveStreams.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -961,9 +961,8 @@ while (true) {
     const {value: chunk, done} = await chunkReader.read();
     if(done){
       break;
-    } else {
-      // Process the data.
     }
+    // Process the data.
   }
 }
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -939,6 +939,35 @@ while (true) {
 }
 </pre>
 
+## Receiving from ReceiveStream ##  {#example-receiving-from-receivestream}
+
+*This section is non-normative.*
+
+Reading from ReceiveStreams can be achieved by calling
+{{UnidirectionalStreamsTransport/receiveStreams()}} method, then getting the
+reader for each {{ReceiveStream}}.
+
+<pre class="example" highlight="js">
+const transport = getTransport();
+const receiveStreamReader = transport.receiveStreams().getReader();
+while (true) {
+  const {value: receiveStream, done} = await receiveStreamReader.read();
+  if (done) {
+    break;
+  }
+  // Process ReceiveStreams created by remote endpoint.
+  const chunkReader = receiveStream.readable.getReader();
+  while(true){
+    const {value: chunk, done} = await chunkReader.read();
+    if(done){
+      break;
+    } else {
+      // Process the data.
+    }
+  }
+}
+</pre>
+
 # Acknowledgements #  {#acknowledgements}
 The editors wish to thank the Working Group chairs and Team Contact, Harald
 Alvestrand, Stefan H&aring;kansson, Bernard Aboba and Dominique

--- a/index.bs
+++ b/index.bs
@@ -957,9 +957,9 @@ while (true) {
   }
   // Process ReceiveStreams created by remote endpoint.
   const chunkReader = receiveStream.readable.getReader();
-  while(true){
+  while (true) {
     const {value: chunk, done} = await chunkReader.read();
-    if(done){
+    if (done) {
       break;
     }
     processTheData(chunk);

--- a/index.bs
+++ b/index.bs
@@ -951,15 +951,16 @@ reader for each {{ReceiveStream}}.
 const transport = getTransport();
 const receiveStreamReader = transport.receiveStreams().getReader();
 while (true) {
-  const {value: receiveStream, done} = await receiveStreamReader.read();
-  if (done) {
+  const {value: receiveStream, done: readingReceiveStreamsDone} =
+      await receiveStreamReader.read();
+  if (readingReceiveStreamsDone) {
     break;
   }
   // Process ReceiveStreams created by remote endpoint.
   const chunkReader = receiveStream.readable.getReader();
   while (true) {
-    const {value: chunk, done} = await chunkReader.read();
-    if (done) {
+    const {value: chunk, done: readingChunksDone} = await chunkReader.read();
+    if (readingChunksDone) {
       break;
     }
     processTheData(chunk);

--- a/index.bs
+++ b/index.bs
@@ -962,7 +962,7 @@ while (true) {
     if(done){
       break;
     }
-    // Process the data.
+    processTheData(chunk);
   }
 }
 </pre>


### PR DESCRIPTION
Section 16 only has examples for datagrams. Receiving chunks from `ReceiveStream`s is a little bit different from receiving datagrams. It requires developers to have a reader to get `ReceiveStream`s first, then another reader to read chunks from each `ReceiveStream`s.