### PR TITLE
Rename QuicTransportOptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -521,18 +521,18 @@ defined in [[!QUIC-DATAGRAM]].
 ## Configuration ##  {#quic-transport-configuration}
 
 <pre class="idl">
-dictionary QuicTransportConfiguration {
-  sequence&lt;RTCDtlsFingerprint&gt; server_certificate_fingerprints;
+dictionary QuicTransportOptions {
+  sequence&lt;RTCDtlsFingerprint&gt; serverCertificateFingerprints;
 };
 </pre>
 
-<dfn dictionary>QuicTransportConfiguration</dfn> is a dictionary of parameters
+<dfn dictionary>QuicTransportOptions</dfn> is a dictionary of parameters
 that determine how QuicTransport connection is established and used.
 
-: <dfn for="QuicTransportConfiguration" dict-member>server_certificate_fingerprints</dfn>
+: <dfn for="QuicTransportOptions" dict-member>serverCertificateFingerprints</dfn>
 :: If non-empty, the user agent SHALL deem a server certificate trusted if and
    only if it can successfully [=verify a certificate fingerprint=] against
-   {{QuicTransportConfiguration/server_certificate_fingerprints}} and satisfies
+   {{QuicTransportOptions/serverCertificateFingerprints}} and satisfies
    [=custom certificate requirements=].  The user agent SHALL ignore any
    fingerprint that uses an unknown {{RTCDtlsFingerprint/algorithm}} or has a
    malformed {{RTCDtlsFingerprint/value}}.  If empty, the user agent SHALL use
@@ -577,7 +577,7 @@ without key rotation.
 <pre class="idl">
 [Exposed=(Window,Worker)]
 interface QuicTransport {
-  constructor(USVString url, optional QuicTransportConfiguration config = {});
+  constructor(USVString url, optional QuicTransportOptions options = {});
   Promise&lt;QuicTransportStats&gt; getStats();
 };
 
@@ -591,7 +591,7 @@ QuicTransport includes WebTransport;
 When the {{QuicTransport/constructor()}} constructor is invoked, the user
 agent MUST run the following steps:
 1. Let |parsedURL| be the [=URL record=] resulting from [=URL parser|parsing=]
-   of {{QuicTransport/constructor(url, config)/url}}.
+   of {{QuicTransport/constructor(url, options)/url}}.
 1. If |parsedURL| is a failure, [=throw=] a {{SyntaxError}} exception.
 1. If |parsedURL| [=scheme=] is not `quic-transport`, [=throw=]
    a {{SyntaxError}} exception.
@@ -626,7 +626,7 @@ agent MUST run the following steps:
        following the procedures in [[!WEB-TRANSPORT-QUIC]] section 3 and using
        |clientOrigin| as the "origin of the client" referenced in section 3.2.1.
        While establishing the connection, follow all of the parameters
-       specified in the {{QuicTransport/constructor(url, config)/config}}.
+       specified in the {{QuicTransport/constructor(url, options)/options}}.
     1. If the connection fails, set |transport|'s {{[[WebTransportState]]}}
        internal slot to `"failed"` and abort these steps.
     1. Set |transport|'s {{[[WebTransportState]]}} internal slot to

--- a/index.html
+++ b/index.html
@@ -1175,7 +1175,7 @@ Possible extra rowspan handling
 		   1. When table < content column, centers table in column.
 		   2. When content < table < available, left-aligns.
 		   3. When table > available, fills available + scroll bar.
-		*/ 
+		*/
 		display: grid;
 		grid-template-columns: minmax(0, 50em);
 	}
@@ -1222,105 +1222,8 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version b43aa594f5014ff14748da1aace9afaa73d2b3e6" name="generator">
+  <meta content="Bikeshed version 40de15f9, updated Thu Jun 11 17:47:04 2020 -0700" name="generator">
   <link href="https://wicg.github.io/web-transport/" rel="canonical">
-  <meta content="53423d3ad5ce2ae7dfc36dba521d7ae078eb4abd" name="document-revision">
-<style>/* style-md-lists */
-
-/* This is a weird hack for me not yet following the commonmark spec
-   regarding paragraph and lists. */
-[data-md] > :first-child {
-    margin-top: 0;
-}
-[data-md] > :last-child {
-    margin-bottom: 0;
-}</style>
-<style>/* style-selflinks */
-
-.heading, .issue, .note, .example, li, dt {
-    position: relative;
-}
-a.self-link {
-    position: absolute;
-    top: 0;
-    left: calc(-1 * (3.5rem - 26px));
-    width: calc(3.5rem - 26px);
-    height: 2em;
-    text-align: center;
-    border: none;
-    transition: opacity .2s;
-    opacity: .5;
-}
-a.self-link:hover {
-    opacity: 1;
-}
-.heading > a.self-link {
-    font-size: 83%;
-}
-li > a.self-link {
-    left: calc(-1 * (3.5rem - 26px) - 2em);
-}
-dfn > a.self-link {
-    top: auto;
-    left: auto;
-    opacity: 0;
-    width: 1.5em;
-    height: 1.5em;
-    background: gray;
-    color: white;
-    font-style: normal;
-    transition: opacity .2s, background-color .2s, color .2s;
-}
-dfn:hover > a.self-link {
-    opacity: 1;
-}
-dfn > a.self-link:hover {
-    color: black;
-}
-
-a.self-link::before            { content: "¶"; }
-.heading > a.self-link::before { content: "§"; }
-dfn > a.self-link::before      { content: "#"; }</style>
-<style>/* style-counters */
-
-body {
-    counter-reset: example figure issue;
-}
-.issue {
-    counter-increment: issue;
-}
-.issue:not(.no-marker)::before {
-    content: "Issue " counter(issue);
-}
-
-.example {
-    counter-increment: example;
-}
-.example:not(.no-marker)::before {
-    content: "Example " counter(example);
-}
-.invalid.example:not(.no-marker)::before,
-.illegal.example:not(.no-marker)::before {
-    content: "Invalid Example" counter(example);
-}
-
-figcaption {
-    counter-increment: figure;
-}
-figcaption:not(.no-marker)::before {
-    content: "Figure " counter(figure) " ";
-}</style>
-<style>/* style-var-click-highlighting */
-
-    var { cursor: pointer; }
-    var.selected0 { background-color: #F4D200; box-shadow: 0 0 0 2px #F4D200; }
-    var.selected1 { background-color: #FF87A2; box-shadow: 0 0 0 2px #FF87A2; }
-    var.selected2 { background-color: #96E885; box-shadow: 0 0 0 2px #96E885; }
-    var.selected3 { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEED2; }
-    var.selected4 { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
-    var.selected5 { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
-    var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
-    </style>
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1383,6 +1286,35 @@ pre .property::before, pre .property::after {
 [data-link-type=biblio] {
     white-space: pre;
 }</style>
+<style>/* style-counters */
+
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}</style>
 <style>/* style-dfn-panel */
 
 .dfn-panel {
@@ -1420,6 +1352,62 @@ pre .property::before, pre .property::after {
 
 .dfn-paneled { cursor: pointer; }
 </style>
+<style>/* style-md-lists */
+
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}</style>
+<style>/* style-selflinks */
+
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: gray;
+    color: white;
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: black;
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }</style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
 .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
@@ -1478,11 +1466,22 @@ c-[vg] { color: #0077aa } /* Name.Variable.Global */
 c-[vi] { color: #0077aa } /* Name.Variable.Instance */
 c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
+<style>/* style-var-click-highlighting */
+
+    var { cursor: pointer; }
+    var.selected0 { background-color: #F4D200; box-shadow: 0 0 0 2px #F4D200; }
+    var.selected1 { background-color: #FF87A2; box-shadow: 0 0 0 2px #FF87A2; }
+    var.selected2 { background-color: #96E885; box-shadow: 0 0 0 2px #96E885; }
+    var.selected3 { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEED2; }
+    var.selected4 { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
+    var.selected5 { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
+    var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+    </style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">WebTransport</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-04-14">14 April 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-06-18">18 June 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1612,6 +1611,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li><a href="#example-datagrams"><span class="secno">16.1</span> <span class="content">Sending a buffer of datagrams</span></a>
       <li><a href="#example-fixed-rate"><span class="secno">16.2</span> <span class="content">Sending datagrams at a fixed rate</span></a>
       <li><a href="#example-receiving-datagrams"><span class="secno">16.3</span> <span class="content">Receiving datagrams</span></a>
+      <li><a href="#example-receiving-from-receivestream"><span class="secno">16.4</span> <span class="content">Receiving from ReceiveStream</span></a>
      </ol>
     <li><a href="#acknowledgements"><span class="secno">17</span> <span class="content">Acknowledgements</span></a>
     <li>
@@ -1664,7 +1664,7 @@ handlers, and the <code class="idl"><a data-link-type="idl" href="https://html.s
 defined in <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
    <p>When referring to exceptions, the terms <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw">throw</a> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception" id="ref-for-dfn-create-exception">create</a> are defined in <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a>.</p>
    <p>The terms <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects" id="ref-for-sec-promise-objects">fulfilled</a>, <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects" id="ref-for-sec-promise-objects①">rejected</a>, <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects" id="ref-for-sec-promise-objects②">resolved</a>, <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects" id="ref-for-sec-promise-objects③">pending</a> and <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects" id="ref-for-sec-promise-objects④">settled</a> used in the context of Promises are defined in <a data-link-type="biblio" href="#biblio-ecmascript-60">[ECMASCRIPT-6.0]</a>.</p>
-   <p>The terms <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class">ReadableStream</a></code> and <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class">WritableStream</a></code> are defined in <a data-link-type="biblio" href="#biblio-whatwg-streams">[WHATWG-STREAMS]</a>.  Note that despite sharing the name "stream", these are
+   <p>The terms <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream">ReadableStream</a></code> and <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream">WritableStream</a></code> are defined in <a data-link-type="biblio" href="#biblio-whatwg-streams">[WHATWG-STREAMS]</a>.  Note that despite sharing the name "stream", these are
 distinct from the IncomingStream, OutgoingStream, and BidirectionalStream
 defined here. The IncomingStream, OutgoingStream, and BidirectionalStream
 defined here correspend to a higher level of abstraction that contain and
@@ -1678,7 +1678,7 @@ produce a form of unreliability.  All stream data is encrypted and
 congestion-controlled.</p>
 <pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#unidirectionalstreamstransport" id="ref-for-unidirectionalstreamstransport"><c- g>UnidirectionalStreamsTransport</c-></a> {
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#sendstream" id="ref-for-sendstream"><c- n>SendStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-createsendstream" id="ref-for-dom-unidirectionalstreamstransport-createsendstream"><c- g>createSendStream</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-sendstreamparameters" id="ref-for-dictdef-sendstreamparameters"><c- n>SendStreamParameters</c-></a> <dfn class="idl-code" data-dfn-for="UnidirectionalStreamsTransport/createSendStream(parameters), UnidirectionalStreamsTransport/createSendStream()" data-dfn-type="argument" data-export id="dom-unidirectionalstreamstransport-createsendstream-parameters-parameters"><code><c- g>parameters</c-></code><a class="self-link" href="#dom-unidirectionalstreamstransport-createsendstream-parameters-parameters"></a></dfn> = {});
-  <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-receivestreams" id="ref-for-dom-unidirectionalstreamstransport-receivestreams"><c- g>receiveStreams</c-></a>();
+  <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-receivestreams" id="ref-for-dom-unidirectionalstreamstransport-receivestreams"><c- g>receiveStreams</c-></a>();
 };
 </pre>
    <h3 class="heading settled" data-level="4.1" id="#unidirectional-streams-transport-methods"><span class="secno">4.1. </span><span class="content">Methods</span><a class="self-link" href="#%23unidirectional-streams-transport-methods"></a></h3>
@@ -1723,7 +1723,7 @@ congestion-controlled.</p>
      </ol>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="UnidirectionalStreamsTransport" data-dfn-type="method" data-export id="dom-unidirectionalstreamstransport-receivestreams"><code>receiveStreams()</code></dfn>
     <dd data-md>
-     <p>Returns a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class②">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream">ReceiveStream</a></code>s that have been received
+     <p>Returns a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream②">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream">ReceiveStream</a></code>s that have been received
  from the remote host.</p>
      <p>When <code>receiveStreams</code> is called, the user agent MUST run the following
  steps:</p>
@@ -1771,7 +1771,7 @@ but retransmissions may be disabled or the stream may aborted to produce a form
 of unreliability.  All stream data is encrypted and congestion-controlled.</p>
 <pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#bidirectionalstreamstransport" id="ref-for-bidirectionalstreamstransport"><c- g>BidirectionalStreamsTransport</c-></a> {
     <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream"><c- n>BidirectionalStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-createbidirectionalstream" id="ref-for-dom-bidirectionalstreamstransport-createbidirectionalstream"><c- g>createBidirectionalStream</c-></a>();
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class③"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-receivebidirectionalstreams" id="ref-for-dom-bidirectionalstreamstransport-receivebidirectionalstreams"><c- g>receiveBidirectionalStreams</c-></a>();
+    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream③"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-receivebidirectionalstreams" id="ref-for-dom-bidirectionalstreamstransport-receivebidirectionalstreams"><c- g>receiveBidirectionalStreams</c-></a>();
 };
 </pre>
    <h3 class="heading settled" data-level="5.1" id="#bidirectional-streams-transport-methods"><span class="secno">5.1. </span><span class="content">Methods</span><a class="self-link" href="#%23bidirectional-streams-transport-methods"></a></h3>
@@ -1820,7 +1820,7 @@ of unreliability.  All stream data is encrypted and congestion-controlled.</p>
      </ol>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="BidirectionalStreamsTransport" data-dfn-type="method" data-export id="dom-bidirectionalstreamstransport-receivebidirectionalstreams"><code>receiveBidirectionalStreams()</code></dfn>
     <dd data-md>
-     <p>Returns a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class④">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream④">BidirectionalStream</a></code>s that have been
+     <p>Returns a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream④">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream④">BidirectionalStream</a></code>s that have been
  received from the remote host.</p>
      <p>When <code>receiveBidirectionalStreams</code> method is called, the user agent MUST run
  the following steps:</p>
@@ -1861,8 +1861,8 @@ Datagrams are sent out of order, unreliably, and have a limited maximum size.
 Datagrams are encrypted and congestion controlled.</p>
 <pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#datagramtransport" id="ref-for-datagramtransport"><c- g>DatagramTransport</c-></a> {
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned short" href="#dom-datagramtransport-maxdatagramsize" id="ref-for-dom-datagramtransport-maxdatagramsize"><c- g>maxDatagramSize</c-></a>;
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class①"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-senddatagrams" id="ref-for-dom-datagramtransport-senddatagrams"><c- g>sendDatagrams</c-></a>();
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑤"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-receivedatagrams" id="ref-for-dom-datagramtransport-receivedatagrams"><c- g>receiveDatagrams</c-></a>();
+    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream①"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-senddatagrams" id="ref-for-dom-datagramtransport-senddatagrams"><c- g>sendDatagrams</c-></a>();
+    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream⑤"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-receivedatagrams" id="ref-for-dom-datagramtransport-receivedatagrams"><c- g>receiveDatagrams</c-></a>();
 };
 </pre>
    <h3 class="heading settled" data-level="6.1" id="datagram-transport-attributes"><span class="secno">6.1. </span><span class="content">Attributes</span><a class="self-link" href="#datagram-transport-attributes"></a></h3>
@@ -1875,7 +1875,7 @@ Datagrams are encrypted and congestion controlled.</p>
    <dl>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="DatagramTransport" data-dfn-type="method" data-export id="dom-datagramtransport-senddatagrams"><code>sendDatagrams()</code></dfn>
     <dd data-md>
-     <p>Sends datagrams that are written to the returned <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class②">WritableStream</a></code>.</p>
+     <p>Sends datagrams that are written to the returned <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream②">WritableStream</a></code>.</p>
      <p>When <code>sendDatagrams</code> is called, the user agent MUST run the following steps:</p>
      <ol>
       <li data-md>
@@ -1972,9 +1972,9 @@ state, state changes, and the ability to close the transport.</p>
       <li data-md>
        <p>Let <var>transport</var> be the <code class="idl"><a data-link-type="idl" href="#webtransport" id="ref-for-webtransport①">WebTransport</a></code>.</p>
       <li data-md>
-       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑥">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedstreams-slot" id="ref-for-dom-quictransport-receivedstreams-slot②">[[ReceivedStreams]]</a></code> internal slot.</p>
+       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream⑥">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedstreams-slot" id="ref-for-dom-quictransport-receivedstreams-slot②">[[ReceivedStreams]]</a></code> internal slot.</p>
       <li data-md>
-       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑦">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedbidirectionalstreams-slot" id="ref-for-dom-quictransport-receivedbidirectionalstreams-slot③">[[ReceivedBidirectionalStreams]]</a></code> internal slot.</p>
+       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream⑦">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedbidirectionalstreams-slot" id="ref-for-dom-quictransport-receivedbidirectionalstreams-slot③">[[ReceivedBidirectionalStreams]]</a></code> internal slot.</p>
       <li data-md>
        <p>For each <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream">OutgoingStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-outgoingstreams-slot" id="ref-for-dom-quictransport-outgoingstreams-slot②">[[OutgoingStreams]]</a></code> internal slot run the following:</p>
        <ol>
@@ -1990,9 +1990,9 @@ state, state changes, and the ability to close the transport.</p>
  an error alert). When the WebTransport’s internal <code class="idl"><a data-link-type="idl" href="#dom-quictransport-webtransportstate-slot" id="ref-for-dom-quictransport-webtransportstate-slot⑤">[[WebTransportState]]</a></code> slot transitions to <code>failed</code> the user agent MUST run the following steps:</p>
      <ol>
       <li data-md>
-       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑧">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedstreams-slot" id="ref-for-dom-quictransport-receivedstreams-slot③">[[ReceivedStreams]]</a></code> internal slot.</p>
+       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream⑧">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedstreams-slot" id="ref-for-dom-quictransport-receivedstreams-slot③">[[ReceivedStreams]]</a></code> internal slot.</p>
       <li data-md>
-       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑨">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedbidirectionalstreams-slot" id="ref-for-dom-quictransport-receivedbidirectionalstreams-slot④">[[ReceivedBidirectionalStreams]]</a></code> internal slot.</p>
+       <p>Close the <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream⑨">ReadableStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedbidirectionalstreams-slot" id="ref-for-dom-quictransport-receivedbidirectionalstreams-slot④">[[ReceivedBidirectionalStreams]]</a></code> internal slot.</p>
       <li data-md>
        <p>For each <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream②">OutgoingStream</a></code> in <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-outgoingstreams-slot" id="ref-for-dom-quictransport-outgoingstreams-slot④">[[OutgoingStreams]]</a></code> internal slot run the following:</p>
        <ol>
@@ -2076,17 +2076,17 @@ with unidirectional QUIC streams as defined in <a data-link-type="biblio" href="
 defined in <a data-link-type="biblio" href="#biblio-quic-transport">[QUIC-TRANSPORT]</a>. Datagrams are implemented with QUIC datagrams as
 defined in <a data-link-type="biblio" href="#biblio-quic-datagram">[QUIC-DATAGRAM]</a>.</p>
    <h3 class="heading settled" data-level="8.1" id="quic-transport-configuration"><span class="secno">8.1. </span><span class="content">Configuration</span><a class="self-link" href="#quic-transport-configuration"></a></h3>
-<pre class="idl highlight def"><c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportconfiguration" id="ref-for-dictdef-quictransportconfiguration"><c- g>QuicTransportConfiguration</c-></a> {
-  <c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint"><c- n>RTCDtlsFingerprint</c-></a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<RTCDtlsFingerprint> " href="#dom-quictransportconfiguration-server_certificate_fingerprints" id="ref-for-dom-quictransportconfiguration-server_certificate_fingerprints"><c- g>server_certificate_fingerprints</c-></a>;
+<pre class="idl highlight def"><c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportoptions" id="ref-for-dictdef-quictransportoptions"><c- g>QuicTransportOptions</c-></a> {
+  <c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint"><c- n>RTCDtlsFingerprint</c-></a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<RTCDtlsFingerprint> " href="#dom-quictransportoptions-servercertificatefingerprints" id="ref-for-dom-quictransportoptions-servercertificatefingerprints"><c- g>serverCertificateFingerprints</c-></a>;
 };
 </pre>
-   <p><dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-quictransportconfiguration"><code>QuicTransportConfiguration</code></dfn> is a dictionary of parameters
+   <p><dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-quictransportoptions"><code>QuicTransportOptions</code></dfn> is a dictionary of parameters
 that determine how QuicTransport connection is established and used.</p>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportConfiguration" data-dfn-type="dict-member" data-export id="dom-quictransportconfiguration-server_certificate_fingerprints"><code>server_certificate_fingerprints</code></dfn>, <span> of type sequence&lt;<a data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint①">RTCDtlsFingerprint</a>></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransportOptions" data-dfn-type="dict-member" data-export id="dom-quictransportoptions-servercertificatefingerprints"><code>serverCertificateFingerprints</code></dfn>, <span> of type sequence&lt;<a data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint①">RTCDtlsFingerprint</a>></span>
     <dd data-md>
      <p>If non-empty, the user agent SHALL deem a server certificate trusted if and
- only if it can successfully <a data-link-type="dfn" href="#verify-a-certificate-fingerprint" id="ref-for-verify-a-certificate-fingerprint">verify a certificate fingerprint</a> against <code class="idl"><a data-link-type="idl" href="#dom-quictransportconfiguration-server_certificate_fingerprints" id="ref-for-dom-quictransportconfiguration-server_certificate_fingerprints①">server_certificate_fingerprints</a></code> and satisfies <a data-link-type="dfn" href="#custom-certificate-requirements" id="ref-for-custom-certificate-requirements">custom certificate requirements</a>.  The user agent SHALL ignore any
+ only if it can successfully <a data-link-type="dfn" href="#verify-a-certificate-fingerprint" id="ref-for-verify-a-certificate-fingerprint">verify a certificate fingerprint</a> against <code class="idl"><a data-link-type="idl" href="#dom-quictransportoptions-servercertificatefingerprints" id="ref-for-dom-quictransportoptions-servercertificatefingerprints①">serverCertificateFingerprints</a></code> and satisfies <a data-link-type="dfn" href="#custom-certificate-requirements" id="ref-for-custom-certificate-requirements">custom certificate requirements</a>.  The user agent SHALL ignore any
  fingerprint that uses an unknown <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-algorithm" id="ref-for-dom-rtcdtlsfingerprint-algorithm">algorithm</a></code> or has a
  malformed <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint-value" id="ref-for-dom-rtcdtlsfingerprint-value">value</a></code>.  If empty, the user agent SHALL use
  certificate verification procedures it would use for normal <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch">fetch</a> operations.</p>
@@ -2133,7 +2133,7 @@ without key rotation.</p>
    <h3 class="heading settled" data-level="8.2" id="quic-transport-definition"><span class="secno">8.2. </span><span class="content">Interface Definition</span><a class="self-link" href="#quic-transport-definition"></a></h3>
 <pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#quictransport" id="ref-for-quictransport"><c- g>QuicTransport</c-></a> {
-  <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="constructor" data-export data-lt="QuicTransport(url, config)|constructor(url, config)|QuicTransport(url)|constructor(url)" id="dom-quictransport-quictransport"><code><c- g>constructor</c-></code></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport/constructor(url, config), QuicTransport/constructor(url)" data-dfn-type="argument" data-export id="dom-quictransport-constructor-url-config-url"><code><c- g>url</c-></code></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-quictransportconfiguration" id="ref-for-dictdef-quictransportconfiguration①"><c- n>QuicTransportConfiguration</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport/constructor(url, config), QuicTransport/constructor(url)" data-dfn-type="argument" data-export id="dom-quictransport-constructor-url-config-config"><code><c- g>config</c-></code></dfn> = {});
+  <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="constructor" data-export data-lt="QuicTransport(url, options)|constructor(url, options)|QuicTransport(url)|constructor(url)" id="dom-quictransport-quictransport"><code><c- g>constructor</c-></code></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport/QuicTransport(url, options), QuicTransport/constructor(url, options), QuicTransport/QuicTransport(url), QuicTransport/constructor(url)" data-dfn-type="argument" data-export id="dom-quictransport-quictransport-url-options-url"><code><c- g>url</c-></code></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-quictransportoptions" id="ref-for-dictdef-quictransportoptions①"><c- n>QuicTransportOptions</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport/QuicTransport(url, options), QuicTransport/constructor(url, options), QuicTransport/QuicTransport(url), QuicTransport/constructor(url)" data-dfn-type="argument" data-export id="dom-quictransport-quictransport-url-options-options"><code><c- g>options</c-></code></dfn> = {});
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-quictransportstats" id="ref-for-dictdef-quictransportstats①"><c- n>QuicTransportStats</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-quictransport-getstats" id="ref-for-dom-quictransport-getstats"><c- g>getStats</c-></a>();
 };
 
@@ -2146,7 +2146,7 @@ without key rotation.</p>
 agent MUST run the following steps:</p>
    <ol>
     <li data-md>
-     <p>Let <var>parsedURL</var> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url">URL record</a> resulting from <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser">parsing</a> of <code class="idl"><a data-link-type="idl" href="#dom-quictransport-constructor-url-config-url" id="ref-for-dom-quictransport-constructor-url-config-url">url</a></code>.</p>
+     <p>Let <var>parsedURL</var> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url">URL record</a> resulting from <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser">parsing</a> of <code class="idl"><a data-link-type="idl" href="#dom-quictransport-quictransport-url-options-url" id="ref-for-dom-quictransport-quictransport-url-options-url">url</a></code>.</p>
     <li data-md>
      <p>If <var>parsedURL</var> is a failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw①">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror" id="ref-for-syntaxerror">SyntaxError</a></code> exception.</p>
     <li data-md>
@@ -2160,19 +2160,19 @@ agent MUST run the following steps:</p>
  representing a sequence of <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream③">OutgoingStream</a></code> objects, initialized to empty.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="attribute" data-export id="dom-quictransport-receivedstreams-slot"><code>[[ReceivedStreams]]</code></dfn> internal slot
- representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⓪">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream①">IncomingStream</a></code> objects, initialized
+ representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①⓪">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream①">IncomingStream</a></code> objects, initialized
  to empty.</p>
     <li data-md>
-     <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="attribute" data-export id="dom-quictransport-receivedbidirectionalstreams-slot"><code>[[ReceivedBidirectionalStreams]]</code></dfn> internal slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①①">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream②">IncomingStream</a></code> objects, initialized to empty.</p>
+     <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="attribute" data-export id="dom-quictransport-receivedbidirectionalstreams-slot"><code>[[ReceivedBidirectionalStreams]]</code></dfn> internal slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①①">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream②">IncomingStream</a></code> objects, initialized to empty.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="attribute" data-export id="dom-quictransport-webtransportstate-slot"><code>[[WebTransportState]]</code></dfn> internal
  slot, initialized to <code>"connecting"</code>.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="attribute" data-export id="dom-quictransport-sentdatagrams-slot"><code>[[SentDatagrams]]</code></dfn> internal slot
- representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class③">WritableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array">Uint8Array</a></code>s, initialized to empty.</p>
+ representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream③">WritableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array">Uint8Array</a></code>s, initialized to empty.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="QuicTransport" data-dfn-type="attribute" data-export id="dom-quictransport-receiveddatagrams-slot"><code>[[ReceivedDatagrams]]</code></dfn> internal
- slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①②">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array①">Uint8Array</a></code>s, initialized to
+ slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①②">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array①">Uint8Array</a></code>s, initialized to
  empty.</p>
     <li data-md>
      <p>Run these steps in parallel:</p>
@@ -2182,7 +2182,7 @@ agent MUST run the following steps:</p>
       <li data-md>
        <p>Establish a QUIC connection to the address identified by <var>parsedURL</var> following the procedures in <a data-link-type="biblio" href="#biblio-web-transport-quic">[WEB-TRANSPORT-QUIC]</a> section 3 and using <var>clientOrigin</var> as the "origin of the client" referenced in section 3.2.1.
  While establishing the connection, follow all of the parameters
- specified in the <code class="idl"><a data-link-type="idl" href="#dom-quictransport-constructor-url-config-config" id="ref-for-dom-quictransport-constructor-url-config-config">config</a></code>.</p>
+ specified in the <code class="idl"><a data-link-type="idl" href="#dom-quictransport-quictransport-url-options-options" id="ref-for-dom-quictransport-quictransport-url-options-options">options</a></code>.</p>
       <li data-md>
        <p>If the connection fails, set <var>transport</var>’s <code class="idl"><a data-link-type="idl" href="#dom-quictransport-webtransportstate-slot" id="ref-for-dom-quictransport-webtransportstate-slot⑥">[[WebTransportState]]</a></code> internal slot to <code>"failed"</code> and abort these steps.</p>
       <li data-md>
@@ -2219,7 +2219,7 @@ agent MUST run the following steps:</p>
 either a <code class="idl"><a data-link-type="idl" href="#sendstream" id="ref-for-sendstream⑤">SendStream</a></code> or a <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream①⓪">BidirectionalStream</a></code>.</p>
 <pre class="idl highlight def">[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
 <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#outgoingstream" id="ref-for-outgoingstream④"><c- g>OutgoingStream</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class④"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WritableStream" href="#dom-outgoingstream-writable" id="ref-for-dom-outgoingstream-writable"><c- g>writable</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream④"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WritableStream" href="#dom-outgoingstream-writable" id="ref-for-dom-outgoingstream-writable"><c- g>writable</c-></a>;
   <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo"><c- n>StreamAbortInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<StreamAbortInfo>" href="#dom-outgoingstream-writingaborted" id="ref-for-dom-outgoingstream-writingaborted"><c- g>writingAborted</c-></a>;
   <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-outgoingstream-abortwriting" id="ref-for-dom-outgoingstream-abortwriting"><c- g>abortWriting</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo①"><c- n>StreamAbortInfo</c-></a> <dfn class="idl-code" data-dfn-for="OutgoingStream/abortWriting(abortInfo), OutgoingStream/abortWriting()" data-dfn-type="argument" data-export id="dom-outgoingstream-abortwriting-abortinfo-abortinfo"><code><c- g>abortInfo</c-></code><a class="self-link" href="#dom-outgoingstream-abortwriting-abortinfo-abortinfo"></a></dfn> = {});
 };
@@ -2230,13 +2230,13 @@ either a <code class="idl"><a data-link-type="idl" href="#sendstream" id="ref-fo
     <li data-md>
      <p>Let <var>stream</var> be the <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream⑥">OutgoingStream</a></code>.</p>
     <li data-md>
-     <p>Let <var>stream</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="OutgoingStream" data-dfn-type="attribute" data-export id="dom-outgoingstream-writable-slot"><code>[[Writable]]</code></dfn> internal slot initialized to a new <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑤">WritableStream</a></code>.</p>
+     <p>Let <var>stream</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="OutgoingStream" data-dfn-type="attribute" data-export id="dom-outgoingstream-writable-slot"><code>[[Writable]]</code></dfn> internal slot initialized to a new <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream⑤">WritableStream</a></code>.</p>
    </ol>
    <h3 class="heading settled" data-level="9.2" id="outgoing-stream-attributes"><span class="secno">9.2. </span><span class="content">Attributes</span><a class="self-link" href="#outgoing-stream-attributes"></a></h3>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="OutgoingStream" data-dfn-type="attribute" data-export id="dom-outgoingstream-writable"><code>writable</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑥">WritableStream</a>, readonly</span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="OutgoingStream" data-dfn-type="attribute" data-export id="dom-outgoingstream-writable"><code>writable</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream⑥">WritableStream</a>, readonly</span>
     <dd data-md>
-     <p>The <code>writable</code> attribute represents a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑦">WritableStream</a></code> (of bytes) that can
+     <p>The <code>writable</code> attribute represents a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream⑦">WritableStream</a></code> (of bytes) that can
  be used to write to the <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream⑦">OutgoingStream</a></code>. On getting it MUST return the
  value of the <code class="idl"><a data-link-type="idl" href="#dom-outgoingstream-writable-slot" id="ref-for-dom-outgoingstream-writable-slot">[[Writable]]</a></code> slot.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="OutgoingStream" data-dfn-type="attribute" data-export id="dom-outgoingstream-writingaborted"><code>writingAborted</code></dfn>, <span> of type Promise&lt;<a data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo②">StreamAbortInfo</a>>, readonly</span>
@@ -2302,7 +2302,7 @@ QUIC, in either a RST_STREAM frame or a STOP_SENDING frame).</p>
 either a <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream②">ReceiveStream</a></code> or a <code class="idl"><a data-link-type="idl" href="#bidirectionalstream" id="ref-for-bidirectionalstream①①">BidirectionalStream</a></code>.</p>
 <pre class="idl highlight def">[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
 <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#incomingstream" id="ref-for-incomingstream③"><c- g>IncomingStream</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①③"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-incomingstream-readable" id="ref-for-dom-incomingstream-readable"><c- g>readable</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①③"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-incomingstream-readable" id="ref-for-dom-incomingstream-readable"><c- g>readable</c-></a>;
   <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑤"><c- n>StreamAbortInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<StreamAbortInfo>" href="#dom-incomingstream-readingaborted" id="ref-for-dom-incomingstream-readingaborted"><c- g>readingAborted</c-></a>;
   <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-incomingstream-abortreading" id="ref-for-dom-incomingstream-abortreading"><c- g>abortReading</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑥"><c- n>StreamAbortInfo</c-></a> <dfn class="idl-code" data-dfn-for="IncomingStream/abortReading(abortInfo), IncomingStream/abortReading()" data-dfn-type="argument" data-export id="dom-incomingstream-abortreading-abortinfo-abortinfo"><code><c- g>abortInfo</c-></code><a class="self-link" href="#dom-incomingstream-abortreading-abortinfo-abortinfo"></a></dfn> = {});
   <c- b>Promise</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer"><c- b>ArrayBuffer</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-incomingstream-arraybuffer" id="ref-for-dom-incomingstream-arraybuffer"><c- g>arrayBuffer</c-></a>();
@@ -2314,13 +2314,13 @@ either a <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref
     <li data-md>
      <p>Let <var>stream</var> be the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑤">IncomingStream</a></code>.</p>
     <li data-md>
-     <p>Let <var>stream</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="attribute" data-export id="dom-incomingstream-readable-slot"><code>[[Readable]]</code></dfn> internal slot initialized to a new <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①④">ReadableStream</a></code>.</p>
+     <p>Let <var>stream</var> have a <dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="attribute" data-export id="dom-incomingstream-readable-slot"><code>[[Readable]]</code></dfn> internal slot initialized to a new <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①④">ReadableStream</a></code>.</p>
    </ol>
    <h3 class="heading settled" data-level="10.2" id="incoming-stream-attributes"><span class="secno">10.2. </span><span class="content">Attributes</span><a class="self-link" href="#incoming-stream-attributes"></a></h3>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="attribute" data-export id="dom-incomingstream-readable"><code>readable</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑤">ReadableStream</a>, readonly</span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="attribute" data-export id="dom-incomingstream-readable"><code>readable</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①⑤">ReadableStream</a>, readonly</span>
     <dd data-md>
-     <p>The <code>readable</code> attribute represents a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑥">ReadableStream</a></code> that can
+     <p>The <code>readable</code> attribute represents a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①⑥">ReadableStream</a></code> that can
  be used to read from the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑥">IncomingStream</a></code>. On getting it MUST return the
  value of the <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream⑦">IncomingStream</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-incomingstream-readable-slot" id="ref-for-dom-incomingstream-readable-slot">[[Readable]]</a></code> slot.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="IncomingStream" data-dfn-type="attribute" data-export id="dom-incomingstream-readingaborted"><code>readingAborted</code></dfn>, <span> of type Promise&lt;<a data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑦">StreamAbortInfo</a>>, readonly</span>
@@ -2399,7 +2399,7 @@ Datagrams are implemented with QUIC datagrams as defined in <a data-link-type="b
    <h3 class="heading settled" data-level="14.2" id="http3-transport-interface"><span class="secno">14.2. </span><span class="content">Interface Definition</span><a class="self-link" href="#http3-transport-interface"></a></h3>
 <pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑥"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#http3transport" id="ref-for-http3transport"><c- g>Http3Transport</c-></a> {
-  <dfn class="dfn-paneled idl-code" data-dfn-for="Http3Transport" data-dfn-type="constructor" data-export data-lt="Http3Transport(url)|constructor(url)" id="dom-http3transport-http3transport"><code><c- g>constructor</c-></code></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Http3Transport/constructor(url)" data-dfn-type="argument" data-export id="dom-http3transport-constructor-url-url"><code><c- g>url</c-></code><a class="self-link" href="#dom-http3transport-constructor-url-url"></a></dfn>);
+  <dfn class="dfn-paneled idl-code" data-dfn-for="Http3Transport" data-dfn-type="constructor" data-export data-lt="Http3Transport(url)|constructor(url)" id="dom-http3transport-http3transport"><code><c- g>constructor</c-></code></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Http3Transport/Http3Transport(url), Http3Transport/constructor(url)" data-dfn-type="argument" data-export id="dom-http3transport-http3transport-url-url"><code><c- g>url</c-></code><a class="self-link" href="#dom-http3transport-http3transport-url-url"></a></dfn>);
 };
 
 <a class="n" data-link-type="idl-name" href="#http3transport" id="ref-for-http3transport①"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#unidirectionalstreamstransport" id="ref-for-unidirectionalstreamstransport⑥"><c- n>UnidirectionalStreamsTransport</c-></a>;
@@ -2419,16 +2419,16 @@ agent MUST run the following steps:</p>
  representing a sequence of <code class="idl"><a data-link-type="idl" href="#outgoingstream" id="ref-for-outgoingstream①④">OutgoingStream</a></code> objects, initialized to empty.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedstreams-slot" id="ref-for-dom-quictransport-receivedstreams-slot④">[[ReceivedStreams]]</a></code> internal slot
- representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑦">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream①④">IncomingStream</a></code> objects, initialized
+ representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①⑦">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream①④">IncomingStream</a></code> objects, initialized
  to empty.</p>
     <li data-md>
-     <p>Let <var>transport</var> have a <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedbidirectionalstreams-slot" id="ref-for-dom-quictransport-receivedbidirectionalstreams-slot⑤">[[ReceivedBidirectionalStreams]]</a></code> internal slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑧">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream①⑤">IncomingStream</a></code> objects, initialized to empty.</p>
+     <p>Let <var>transport</var> have a <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receivedbidirectionalstreams-slot" id="ref-for-dom-quictransport-receivedbidirectionalstreams-slot⑤">[[ReceivedBidirectionalStreams]]</a></code> internal slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①⑧">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="#incomingstream" id="ref-for-incomingstream①⑤">IncomingStream</a></code> objects, initialized to empty.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <code class="idl"><a data-link-type="idl" href="#dom-quictransport-sentdatagrams-slot" id="ref-for-dom-quictransport-sentdatagrams-slot①">[[SentDatagrams]]</a></code> internal slot
- representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class⑧">WritableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array②">Uint8Array</a></code>s, initialized to empty.</p>
+ representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream⑧">WritableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array②">Uint8Array</a></code>s, initialized to empty.</p>
     <li data-md>
      <p>Let <var>transport</var> have a <code class="idl"><a data-link-type="idl" href="#dom-quictransport-receiveddatagrams-slot" id="ref-for-dom-quictransport-receiveddatagrams-slot②">[[ReceivedDatagrams]]</a></code> internal
- slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①⑨">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array③">Uint8Array</a></code>s, initialized to
+ slot representing a <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①⑨">ReadableStream</a></code> of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array③">Uint8Array</a></code>s, initialized to
  empty.</p>
     <li data-md>
      <p>Run these steps in parallel:</p>
@@ -2540,6 +2540,29 @@ values indicating that packets are not being processed quickly enough.</p>
     <c- k>break</c-><c- p>;</c->
   <c- p>}</c->
   <c- c1>// Process the data</c->
+<c- p>}</c->
+</pre>
+   <h3 class="heading settled" data-level="16.4" id="example-receiving-from-receivestream"><span class="secno">16.4. </span><span class="content">Receiving from ReceiveStream</span><a class="self-link" href="#example-receiving-from-receivestream"></a></h3>
+   <p><em>This section is non-normative.</em></p>
+   <p>Reading from ReceiveStreams can be achieved by calling <code class="idl"><a data-link-type="idl" href="#dom-unidirectionalstreamstransport-receivestreams" id="ref-for-dom-unidirectionalstreamstransport-receivestreams①">receiveStreams()</a></code> method, then getting the
+reader for each <code class="idl"><a data-link-type="idl" href="#receivestream" id="ref-for-receivestream⑤">ReceiveStream</a></code>.</p>
+<pre class="example highlight" id="example-5ead2914"><a class="self-link" href="#example-5ead2914"></a><c- kr>const</c-> transport <c- o>=</c-> getTransport<c- p>();</c->
+<c- kr>const</c-> receiveStreamReader <c- o>=</c-> transport<c- p>.</c->receiveStreams<c- p>().</c->getReader<c- p>();</c->
+<c- k>while</c-> <c- p>(</c-><c- kc>true</c-><c- p>)</c-> <c- p>{</c->
+  <c- kr>const</c-> <c- p>{</c->value<c- o>:</c-> receiveStream<c- p>,</c-> done<c- o>:</c-> readingReceiveStreamsDone<c- p>}</c-> <c- o>=</c->
+      await receiveStreamReader<c- p>.</c->read<c- p>();</c->
+  <c- k>if</c-> <c- p>(</c->readingReceiveStreamsDone<c- p>)</c-> <c- p>{</c->
+    <c- k>break</c-><c- p>;</c->
+  <c- p>}</c->
+  <c- c1>// Process ReceiveStreams created by remote endpoint.</c->
+  <c- kr>const</c-> chunkReader <c- o>=</c-> receiveStream<c- p>.</c->readable<c- p>.</c->getReader<c- p>();</c->
+  <c- k>while</c-> <c- p>(</c-><c- kc>true</c-><c- p>)</c-> <c- p>{</c->
+    <c- kr>const</c-> <c- p>{</c->value<c- o>:</c-> chunk<c- p>,</c-> done<c- o>:</c-> readingChunksDone<c- p>}</c-> <c- o>=</c-> await chunkReader<c- p>.</c->read<c- p>();</c->
+    <c- k>if</c-> <c- p>(</c->readingChunksDone<c- p>)</c-> <c- p>{</c->
+      <c- k>break</c-><c- p>;</c->
+    <c- p>}</c->
+    processTheData<c- p>(</c->chunk<c- p>);</c->
+  <c- p>}</c->
 <c- p>}</c->
 </pre>
    <h2 class="heading settled" data-level="17" id="acknowledgements"><span class="secno">17. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
@@ -2706,7 +2729,7 @@ use in this specification.</p>
      <li><a href="#dom-http3transport-http3transport">constructor for Http3Transport</a><span>, in §14.2</span>
      <li><a href="#dom-quictransport-quictransport">constructor for QuicTransport</a><span>, in §8.2</span>
     </ul>
-   <li><a href="#dom-quictransport-quictransport">constructor(url, config)</a><span>, in §8.2</span>
+   <li><a href="#dom-quictransport-quictransport">constructor(url, options)</a><span>, in §8.2</span>
    <li><a href="#dom-bidirectionalstreamstransport-createbidirectionalstream">createBidirectionalStream()</a><span>, in §5.1</span>
    <li><a href="#dom-unidirectionalstreamstransport-createsendstream">createSendStream()</a><span>, in §4.1</span>
    <li><a href="#dom-unidirectionalstreamstransport-createsendstream">createSendStream(parameters)</a><span>, in §4.1</span>
@@ -2735,12 +2758,12 @@ use in this specification.</p>
    <li><a href="#dom-quictransportstats-packetsreceived">packetsReceived</a><span>, in §7.5</span>
    <li><a href="#dom-quictransportstats-packetssent">packetsSent</a><span>, in §7.5</span>
    <li><a href="#quictransport">QuicTransport</a><span>, in §8</span>
-   <li><a href="#dictdef-quictransportconfiguration">QuicTransportConfiguration</a><span>, in §8.1</span>
+   <li><a href="#dictdef-quictransportoptions">QuicTransportOptions</a><span>, in §8.1</span>
    <li><a href="#dictdef-quictransportstats">QuicTransportStats</a><span>, in §7.5</span>
    <li><a href="#dom-quictransport-quictransport">QuicTransport(url)</a><span>, in §8.2</span>
-   <li><a href="#dom-quictransport-quictransport">QuicTransport(url, config)</a><span>, in §8.2</span>
-   <li><a href="#dom-incomingstream-readable">readable</a><span>, in §10.2</span>
+   <li><a href="#dom-quictransport-quictransport">QuicTransport(url, options)</a><span>, in §8.2</span>
    <li><a href="#dom-incomingstream-readable-slot">[[Readable]]</a><span>, in §10.1</span>
+   <li><a href="#dom-incomingstream-readable">readable</a><span>, in §10.2</span>
    <li><a href="#dom-incomingstream-readingaborted">readingAborted</a><span>, in §10.2</span>
    <li><a href="#dom-webtransportcloseinfo-reason">reason</a><span>, in §7.4</span>
    <li><a href="#dom-bidirectionalstreamstransport-receivebidirectionalstreams">receiveBidirectionalStreams()</a><span>, in §5.1</span>
@@ -2754,7 +2777,7 @@ use in this specification.</p>
    <li><a href="#sendstream">SendStream</a><span>, in §12</span>
    <li><a href="#dictdef-sendstreamparameters">SendStreamParameters</a><span>, in §4.3</span>
    <li><a href="#dom-quictransport-sentdatagrams-slot">[[SentDatagrams]]</a><span>, in §8.2</span>
-   <li><a href="#dom-quictransportconfiguration-server_certificate_fingerprints">server_certificate_fingerprints</a><span>, in §8.1</span>
+   <li><a href="#dom-quictransportoptions-servercertificatefingerprints">serverCertificateFingerprints</a><span>, in §8.1</span>
    <li><a href="#dom-webtransport-state">state</a><span>, in §7.1</span>
    <li><a href="#dictdef-streamabortinfo">StreamAbortInfo</a><span>, in §9.4</span>
    <li><a href="#dom-quictransportstats-timestamp">timestamp</a><span>, in §7.5</span>
@@ -3018,34 +3041,34 @@ use in this specification.</p>
     <li><a href="#ref-for-dom-rtcdtlsfingerprint-value">8.1. Configuration</a> <a href="#ref-for-dom-rtcdtlsfingerprint-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rs-class">
-   <a href="https://streams.spec.whatwg.org/#rs-class">https://streams.spec.whatwg.org/#rs-class</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-readablestream">
+   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-rs-class">3. Terminology</a>
-    <li><a href="#ref-for-rs-class①">4. UnidirectionalStreamsTransport Mixin</a>
-    <li><a href="#ref-for-rs-class②">4.1. Methods</a>
-    <li><a href="#ref-for-rs-class③">5. BidirectionalStreamsTransport Mixin</a>
-    <li><a href="#ref-for-rs-class④">5.1. Methods</a>
-    <li><a href="#ref-for-rs-class⑤">6. DatagramTransport Mixin</a>
-    <li><a href="#ref-for-rs-class⑥">7.3. WebTransportState Enum</a> <a href="#ref-for-rs-class⑦">(2)</a> <a href="#ref-for-rs-class⑧">(3)</a> <a href="#ref-for-rs-class⑨">(4)</a>
-    <li><a href="#ref-for-rs-class①⓪">8.2. Interface Definition</a> <a href="#ref-for-rs-class①①">(2)</a> <a href="#ref-for-rs-class①②">(3)</a>
-    <li><a href="#ref-for-rs-class①③">10. Interface Mixin IncomingStream</a>
-    <li><a href="#ref-for-rs-class①④">10.1. Overview</a>
-    <li><a href="#ref-for-rs-class①⑤">10.2. Attributes</a> <a href="#ref-for-rs-class①⑥">(2)</a>
-    <li><a href="#ref-for-rs-class①⑦">14.2.1. Constructors</a> <a href="#ref-for-rs-class①⑧">(2)</a> <a href="#ref-for-rs-class①⑨">(3)</a>
+    <li><a href="#ref-for-readablestream">3. Terminology</a>
+    <li><a href="#ref-for-readablestream①">4. UnidirectionalStreamsTransport Mixin</a>
+    <li><a href="#ref-for-readablestream②">4.1. Methods</a>
+    <li><a href="#ref-for-readablestream③">5. BidirectionalStreamsTransport Mixin</a>
+    <li><a href="#ref-for-readablestream④">5.1. Methods</a>
+    <li><a href="#ref-for-readablestream⑤">6. DatagramTransport Mixin</a>
+    <li><a href="#ref-for-readablestream⑥">7.3. WebTransportState Enum</a> <a href="#ref-for-readablestream⑦">(2)</a> <a href="#ref-for-readablestream⑧">(3)</a> <a href="#ref-for-readablestream⑨">(4)</a>
+    <li><a href="#ref-for-readablestream①⓪">8.2. Interface Definition</a> <a href="#ref-for-readablestream①①">(2)</a> <a href="#ref-for-readablestream①②">(3)</a>
+    <li><a href="#ref-for-readablestream①③">10. Interface Mixin IncomingStream</a>
+    <li><a href="#ref-for-readablestream①④">10.1. Overview</a>
+    <li><a href="#ref-for-readablestream①⑤">10.2. Attributes</a> <a href="#ref-for-readablestream①⑥">(2)</a>
+    <li><a href="#ref-for-readablestream①⑦">14.2.1. Constructors</a> <a href="#ref-for-readablestream①⑧">(2)</a> <a href="#ref-for-readablestream①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ws-class">
-   <a href="https://streams.spec.whatwg.org/#ws-class">https://streams.spec.whatwg.org/#ws-class</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-writablestream">
+   <a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ws-class">3. Terminology</a>
-    <li><a href="#ref-for-ws-class①">6. DatagramTransport Mixin</a>
-    <li><a href="#ref-for-ws-class②">6.2. Methods</a>
-    <li><a href="#ref-for-ws-class③">8.2. Interface Definition</a>
-    <li><a href="#ref-for-ws-class④">9. Interface Mixin OutgoingStream</a>
-    <li><a href="#ref-for-ws-class⑤">9.1. Overview</a>
-    <li><a href="#ref-for-ws-class⑥">9.2. Attributes</a> <a href="#ref-for-ws-class⑦">(2)</a>
-    <li><a href="#ref-for-ws-class⑧">14.2.1. Constructors</a>
+    <li><a href="#ref-for-writablestream">3. Terminology</a>
+    <li><a href="#ref-for-writablestream①">6. DatagramTransport Mixin</a>
+    <li><a href="#ref-for-writablestream②">6.2. Methods</a>
+    <li><a href="#ref-for-writablestream③">8.2. Interface Definition</a>
+    <li><a href="#ref-for-writablestream④">9. Interface Mixin OutgoingStream</a>
+    <li><a href="#ref-for-writablestream⑤">9.1. Overview</a>
+    <li><a href="#ref-for-writablestream⑥">9.2. Attributes</a> <a href="#ref-for-writablestream⑦">(2)</a>
+    <li><a href="#ref-for-writablestream⑧">14.2.1. Constructors</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -3120,8 +3143,8 @@ use in this specification.</p>
    <li>
     <a data-link-type="biblio">[WHATWG-STREAMS]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-rs-class" style="color:initial">ReadableStream</span>
-     <li><span class="dfn-paneled" id="term-for-ws-class" style="color:initial">WritableStream</span>
+     <li><span class="dfn-paneled" id="term-for-readablestream" style="color:initial">ReadableStream</span>
+     <li><span class="dfn-paneled" id="term-for-writablestream" style="color:initial">WritableStream</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -3170,115 +3193,115 @@ use in this specification.</p>
    <dd>E. Rescorla. <a href="https://tools.ietf.org/html/rfc8446">The Transport Layer Security (TLS) Protocol Version 1.3</a>. August 2018. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc8446">https://tools.ietf.org/html/rfc8446</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#unidirectionalstreamstransport" id="ref-for-unidirectionalstreamstransport⑦"><c- g>UnidirectionalStreamsTransport</c-></a> {
-  <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#sendstream" id="ref-for-sendstream⑧"><c- n>SendStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-createsendstream" id="ref-for-dom-unidirectionalstreamstransport-createsendstream①"><c- g>createSendStream</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-sendstreamparameters" id="ref-for-dictdef-sendstreamparameters②"><c- n>SendStreamParameters</c-></a> <a href="#dom-unidirectionalstreamstransport-createsendstream-parameters-parameters"><code><c- g>parameters</c-></code></a> = {});
-  <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①①⓪"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-receivestreams" id="ref-for-dom-unidirectionalstreamstransport-receivestreams①"><c- g>receiveStreams</c-></a>();
+<pre class="idl highlight def"><c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#unidirectionalstreamstransport"><c- g>UnidirectionalStreamsTransport</c-></a> {
+  <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#sendstream"><c- n>SendStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-createsendstream"><c- g>createSendStream</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-sendstreamparameters"><c- n>SendStreamParameters</c-></a> <a href="#dom-unidirectionalstreamstransport-createsendstream-parameters-parameters"><code><c- g>parameters</c-></code></a> = {});
+  <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#readablestream"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-unidirectionalstreamstransport-receivestreams"><c- g>receiveStreams</c-></a>();
 };
 
-<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-sendstreamparameters" id="ref-for-dictdef-sendstreamparameters①①"><c- g>SendStreamParameters</c-></a> {
+<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-sendstreamparameters"><c- g>SendStreamParameters</c-></a> {
 };
 
-<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#bidirectionalstreamstransport" id="ref-for-bidirectionalstreamstransport⑧"><c- g>BidirectionalStreamsTransport</c-></a> {
-    <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream①⑤"><c- n>BidirectionalStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-createbidirectionalstream" id="ref-for-dom-bidirectionalstreamstransport-createbidirectionalstream②"><c- g>createBidirectionalStream</c-></a>();
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class③①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-receivebidirectionalstreams" id="ref-for-dom-bidirectionalstreamstransport-receivebidirectionalstreams①"><c- g>receiveBidirectionalStreams</c-></a>();
+<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#bidirectionalstreamstransport"><c- g>BidirectionalStreamsTransport</c-></a> {
+    <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#bidirectionalstream"><c- n>BidirectionalStream</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-createbidirectionalstream"><c- g>createBidirectionalStream</c-></a>();
+    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#readablestream"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-bidirectionalstreamstransport-receivebidirectionalstreams"><c- g>receiveBidirectionalStreams</c-></a>();
 };
 
-<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#datagramtransport" id="ref-for-datagramtransport⑦"><c- g>DatagramTransport</c-></a> {
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short⑥"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned short" href="#dom-datagramtransport-maxdatagramsize" id="ref-for-dom-datagramtransport-maxdatagramsize①"><c- g>maxDatagramSize</c-></a>;
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class①①"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-senddatagrams" id="ref-for-dom-datagramtransport-senddatagrams④"><c- g>sendDatagrams</c-></a>();
-    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class⑤①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-receivedatagrams" id="ref-for-dom-datagramtransport-receivedatagrams③"><c- g>receiveDatagrams</c-></a>();
+<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#datagramtransport"><c- g>DatagramTransport</c-></a> {
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned short" href="#dom-datagramtransport-maxdatagramsize"><c- g>maxDatagramSize</c-></a>;
+    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#writablestream"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-senddatagrams"><c- g>sendDatagrams</c-></a>();
+    <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#readablestream"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="method" href="#dom-datagramtransport-receivedatagrams"><c- g>receiveDatagrams</c-></a>();
 };
 
 <c- b>interface</c-> <c- b>mixin</c-> <a href="#webtransport"><code><c- g>WebTransport</c-></code></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#enumdef-webtransportstate" id="ref-for-enumdef-webtransportstate③"><c- n>WebTransportState</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WebTransportState" href="#dom-webtransport-state" id="ref-for-dom-webtransport-state⑤①"><c- g>state</c-></a>;
-  <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-webtransportcloseinfo" id="ref-for-dictdef-webtransportcloseinfo⑤"><c- n>WebTransportCloseInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<WebTransportCloseInfo>" href="#dom-webtransport-closed" id="ref-for-dom-webtransport-closed①"><c- g>closed</c-></a>;
-  <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-webtransport-close" id="ref-for-dom-webtransport-close③"><c- g>close</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-webtransportcloseinfo" id="ref-for-dictdef-webtransportcloseinfo①①"><c- n>WebTransportCloseInfo</c-></a> <a href="#dom-webtransport-close-closeinfo-closeinfo"><code><c- g>closeInfo</c-></code></a> = {});
-  <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler①①"><c- n>EventHandler</c-></a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler" href="#dom-webtransport-onstatechange" id="ref-for-dom-webtransport-onstatechange①"><c- g>onstatechange</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#enumdef-webtransportstate"><c- n>WebTransportState</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WebTransportState" href="#dom-webtransport-state"><c- g>state</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-webtransportcloseinfo"><c- n>WebTransportCloseInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<WebTransportCloseInfo>" href="#dom-webtransport-closed"><c- g>closed</c-></a>;
+  <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-webtransport-close"><c- g>close</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-webtransportcloseinfo"><c- n>WebTransportCloseInfo</c-></a> <a href="#dom-webtransport-close-closeinfo-closeinfo"><code><c- g>closeInfo</c-></code></a> = {});
+  <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler"><c- n>EventHandler</c-></a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler" href="#dom-webtransport-onstatechange"><c- g>onstatechange</c-></a>;
 };
 
-<c- b>enum</c-> <a class="idl-code" data-link-type="enum" href="#enumdef-webtransportstate" id="ref-for-enumdef-webtransportstate②①"><c- g>WebTransportState</c-></a> {
-  <a class="idl-code" data-link-type="enum-value" href="#dom-webtransportstate-connecting" id="ref-for-dom-webtransportstate-connecting①"><c- s>"connecting"</c-></a>,
-  <a class="idl-code" data-link-type="enum-value" href="#dom-webtransportstate-connected" id="ref-for-dom-webtransportstate-connected①"><c- s>"connected"</c-></a>,
-  <a class="idl-code" data-link-type="enum-value" href="#dom-webtransportstate-closed" id="ref-for-dom-webtransportstate-closed①"><c- s>"closed"</c-></a>,
-  <a class="idl-code" data-link-type="enum-value" href="#dom-webtransportstate-failed" id="ref-for-dom-webtransportstate-failed①"><c- s>"failed"</c-></a>
+<c- b>enum</c-> <a class="idl-code" data-link-type="enum" href="#enumdef-webtransportstate"><c- g>WebTransportState</c-></a> {
+  <a class="idl-code" data-link-type="enum-value" href="#dom-webtransportstate-connecting"><c- s>"connecting"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-webtransportstate-connected"><c- s>"connected"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-webtransportstate-closed"><c- s>"closed"</c-></a>,
+  <a class="idl-code" data-link-type="enum-value" href="#dom-webtransportstate-failed"><c- s>"failed"</c-></a>
 };
 
-<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-webtransportcloseinfo" id="ref-for-dictdef-webtransportcloseinfo④①"><c- g>WebTransportCloseInfo</c-></a> {
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②①"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-webtransportcloseinfo-errorcode" id="ref-for-dom-webtransportcloseinfo-errorcode①①"><c- g>errorCode</c-></a> = 0;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a> <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-webtransportcloseinfo-reason" id="ref-for-dom-webtransportcloseinfo-reason①①"><c- g>reason</c-></a> = "";
+<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-webtransportcloseinfo"><c- g>WebTransportCloseInfo</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-webtransportcloseinfo-errorcode"><c- g>errorCode</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-webtransportcloseinfo-reason"><c- g>reason</c-></a> = "";
 };
 
-<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportstats" id="ref-for-dictdef-quictransportstats③"><c- g>QuicTransportStats</c-></a> {
-  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp④"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-timestamp" id="ref-for-dom-quictransportstats-timestamp①"><c- g>timestamp</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long⑧"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytessent" id="ref-for-dom-quictransportstats-bytessent①"><c- g>bytesSent</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetssent" id="ref-for-dom-quictransportstats-packetssent①"><c- g>packetsSent</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numoutgoingstreamscreated" id="ref-for-dom-quictransportstats-numoutgoingstreamscreated①"><c- g>numOutgoingStreamsCreated</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numincomingstreamscreated" id="ref-for-dom-quictransportstats-numincomingstreamscreated①"><c- g>numIncomingStreamsCreated</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long②①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytesreceived" id="ref-for-dom-quictransportstats-bytesreceived①"><c- g>bytesReceived</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long③①"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetsreceived" id="ref-for-dom-quictransportstats-packetsreceived①"><c- g>packetsReceived</c-></a>;
-  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrtt" id="ref-for-dom-quictransportstats-minrtt①"><c- g>minRtt</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numreceiveddatagramsdropped" id="ref-for-dom-quictransportstats-numreceiveddatagramsdropped①"><c- g>numReceivedDatagramsDropped</c-></a>;
+<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportstats"><c- g>QuicTransportStats</c-></a> {
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-timestamp"><c- g>timestamp</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytessent"><c- g>bytesSent</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetssent"><c- g>packetsSent</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numoutgoingstreamscreated"><c- g>numOutgoingStreamsCreated</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numincomingstreamscreated"><c- g>numIncomingStreamsCreated</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-bytesreceived"><c- g>bytesReceived</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long long " href="#dom-quictransportstats-packetsreceived"><c- g>packetsReceived</c-></a>;
+  <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-quictransportstats-minrtt"><c- g>minRtt</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-quictransportstats-numreceiveddatagramsdropped"><c- g>numReceivedDatagramsDropped</c-></a>;
 };
 
-<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportconfiguration" id="ref-for-dictdef-quictransportconfiguration②"><c- g>QuicTransportConfiguration</c-></a> {
-  <c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint" id="ref-for-dom-rtcdtlsfingerprint②"><c- n>RTCDtlsFingerprint</c-></a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<RTCDtlsFingerprint> " href="#dom-quictransportconfiguration-server_certificate_fingerprints" id="ref-for-dom-quictransportconfiguration-server_certificate_fingerprints②"><c- g>server_certificate_fingerprints</c-></a>;
+<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-quictransportoptions"><c- g>QuicTransportOptions</c-></a> {
+  <c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/webrtc/#dom-rtcdtlsfingerprint"><c- n>RTCDtlsFingerprint</c-></a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<RTCDtlsFingerprint> " href="#dom-quictransportoptions-servercertificatefingerprints"><c- g>serverCertificateFingerprints</c-></a>;
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑦"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
-<c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#quictransport" id="ref-for-quictransport⑧"><c- g>QuicTransport</c-></a> {
-  <a href="#dom-quictransport-quictransport"><code><c- g>constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><c- b>USVString</c-></a> <a href="#dom-quictransport-constructor-url-config-url"><code><c- g>url</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-quictransportconfiguration" id="ref-for-dictdef-quictransportconfiguration①①"><c- n>QuicTransportConfiguration</c-></a> <a href="#dom-quictransport-constructor-url-config-config"><code><c- g>config</c-></code></a> = {});
-  <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-quictransportstats" id="ref-for-dictdef-quictransportstats①①"><c- n>QuicTransportStats</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-quictransport-getstats" id="ref-for-dom-quictransport-getstats①"><c- g>getStats</c-></a>();
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
+<c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#quictransport"><c- g>QuicTransport</c-></a> {
+  <a href="#dom-quictransport-quictransport"><code><c- g>constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><c- b>USVString</c-></a> <a href="#dom-quictransport-quictransport-url-options-url"><code><c- g>url</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-quictransportoptions"><c- n>QuicTransportOptions</c-></a> <a href="#dom-quictransport-quictransport-url-options-options"><code><c- g>options</c-></code></a> = {});
+  <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-quictransportstats"><c- n>QuicTransportStats</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-quictransport-getstats"><c- g>getStats</c-></a>();
 };
 
-<a class="n" data-link-type="idl-name" href="#quictransport" id="ref-for-quictransport①①"><c- n>QuicTransport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#unidirectionalstreamstransport" id="ref-for-unidirectionalstreamstransport④①"><c- n>UnidirectionalStreamsTransport</c-></a>;
-<a class="n" data-link-type="idl-name" href="#quictransport" id="ref-for-quictransport②①"><c- n>QuicTransport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#bidirectionalstreamstransport" id="ref-for-bidirectionalstreamstransport⑤①"><c- n>BidirectionalStreamsTransport</c-></a>;
-<a class="n" data-link-type="idl-name" href="#quictransport" id="ref-for-quictransport③①"><c- n>QuicTransport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#datagramtransport" id="ref-for-datagramtransport③①"><c- n>DatagramTransport</c-></a>;
-<a class="n" data-link-type="idl-name" href="#quictransport" id="ref-for-quictransport④①"><c- n>QuicTransport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#webtransport" id="ref-for-webtransport④①"><c- n>WebTransport</c-></a>;
+<a class="n" data-link-type="idl-name" href="#quictransport"><c- n>QuicTransport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#unidirectionalstreamstransport"><c- n>UnidirectionalStreamsTransport</c-></a>;
+<a class="n" data-link-type="idl-name" href="#quictransport"><c- n>QuicTransport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#bidirectionalstreamstransport"><c- n>BidirectionalStreamsTransport</c-></a>;
+<a class="n" data-link-type="idl-name" href="#quictransport"><c- n>QuicTransport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#datagramtransport"><c- n>DatagramTransport</c-></a>;
+<a class="n" data-link-type="idl-name" href="#quictransport"><c- n>QuicTransport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#webtransport"><c- n>WebTransport</c-></a>;
 
-[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
-<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#outgoingstream" id="ref-for-outgoingstream④①"><c- g>OutgoingStream</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#ws-class" id="ref-for-ws-class④①"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WritableStream" href="#dom-outgoingstream-writable" id="ref-for-dom-outgoingstream-writable①"><c- g>writable</c-></a>;
-  <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑨"><c- n>StreamAbortInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<StreamAbortInfo>" href="#dom-outgoingstream-writingaborted" id="ref-for-dom-outgoingstream-writingaborted①"><c- g>writingAborted</c-></a>;
-  <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-outgoingstream-abortwriting" id="ref-for-dom-outgoingstream-abortwriting①"><c- g>abortWriting</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo①①"><c- n>StreamAbortInfo</c-></a> <a href="#dom-outgoingstream-abortwriting-abortinfo-abortinfo"><code><c- g>abortInfo</c-></code></a> = {});
+[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
+<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#outgoingstream"><c- g>OutgoingStream</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#writablestream"><c- n>WritableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="WritableStream" href="#dom-outgoingstream-writable"><c- g>writable</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo"><c- n>StreamAbortInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<StreamAbortInfo>" href="#dom-outgoingstream-writingaborted"><c- g>writingAborted</c-></a>;
+  <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-outgoingstream-abortwriting"><c- g>abortWriting</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo"><c- n>StreamAbortInfo</c-></a> <a href="#dom-outgoingstream-abortwriting-abortinfo-abortinfo"><code><c- g>abortInfo</c-></code></a> = {});
 };
 
-<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo④①"><c- g>StreamAbortInfo</c-></a> {
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short④①"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-streamabortinfo-errorcode" id="ref-for-dom-streamabortinfo-errorcode①①"><c- g>errorCode</c-></a> = 0;
+<c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="#dictdef-streamabortinfo"><c- g>StreamAbortInfo</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-streamabortinfo-errorcode"><c- g>errorCode</c-></a> = 0;
 };
 
-[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
-<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#incomingstream" id="ref-for-incomingstream③①"><c- g>IncomingStream</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#rs-class" id="ref-for-rs-class①③①"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-incomingstream-readable" id="ref-for-dom-incomingstream-readable①"><c- g>readable</c-></a>;
-  <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑤①"><c- n>StreamAbortInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<StreamAbortInfo>" href="#dom-incomingstream-readingaborted" id="ref-for-dom-incomingstream-readingaborted①"><c- g>readingAborted</c-></a>;
-  <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-incomingstream-abortreading" id="ref-for-dom-incomingstream-abortreading①"><c- g>abortReading</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo" id="ref-for-dictdef-streamabortinfo⑥①"><c- n>StreamAbortInfo</c-></a> <a href="#dom-incomingstream-abortreading-abortinfo-abortinfo"><code><c- g>abortInfo</c-></code></a> = {});
-  <c- b>Promise</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-ArrayBuffer" id="ref-for-idl-ArrayBuffer①"><c- b>ArrayBuffer</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-incomingstream-arraybuffer" id="ref-for-dom-incomingstream-arraybuffer①"><c- g>arrayBuffer</c-></a>();
+[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
+<c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="#incomingstream"><c- g>IncomingStream</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://streams.spec.whatwg.org/#readablestream"><c- n>ReadableStream</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="ReadableStream" href="#dom-incomingstream-readable"><c- g>readable</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo"><c- n>StreamAbortInfo</c-></a>> <a class="idl-code" data-link-type="attribute" data-readonly data-type="Promise<StreamAbortInfo>" href="#dom-incomingstream-readingaborted"><c- g>readingAborted</c-></a>;
+  <c- b>void</c-> <a class="idl-code" data-link-type="method" href="#dom-incomingstream-abortreading"><c- g>abortReading</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-streamabortinfo"><c- n>StreamAbortInfo</c-></a> <a href="#dom-incomingstream-abortreading-abortinfo-abortinfo"><code><c- g>abortInfo</c-></code></a> = {});
+  <c- b>Promise</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-ArrayBuffer"><c- b>ArrayBuffer</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-incomingstream-arraybuffer"><c- g>arrayBuffer</c-></a>();
 };
 
-[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
+[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
 <c- b>interface</c-> <a href="#bidirectionalstream"><code><c- g>BidirectionalStream</c-></code></a> {
 };
-<a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream①②①"><c- n>BidirectionalStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#outgoingstream" id="ref-for-outgoingstream①②①"><c- n>OutgoingStream</c-></a>;
-<a class="n" data-link-type="idl-name" href="#bidirectionalstream" id="ref-for-bidirectionalstream①③①"><c- n>BidirectionalStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream" id="ref-for-incomingstream①②①"><c- n>IncomingStream</c-></a>;
+<a class="n" data-link-type="idl-name" href="#bidirectionalstream"><c- n>BidirectionalStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#outgoingstream"><c- n>OutgoingStream</c-></a>;
+<a class="n" data-link-type="idl-name" href="#bidirectionalstream"><c- n>BidirectionalStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream"><c- n>IncomingStream</c-></a>;
 
-[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
+[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
 <c- b>interface</c-> <a href="#sendstream"><code><c- g>SendStream</c-></code></a> {
 };
-<a class="n" data-link-type="idl-name" href="#sendstream" id="ref-for-sendstream⑥①"><c- n>SendStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#outgoingstream" id="ref-for-outgoingstream①③①"><c- n>OutgoingStream</c-></a>;
+<a class="n" data-link-type="idl-name" href="#sendstream"><c- n>SendStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#outgoingstream"><c- n>OutgoingStream</c-></a>;
 
-[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
+[ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->) ]
 <c- b>interface</c-> <a href="#receivestream"><code><c- g>ReceiveStream</c-></code></a> {
 };
-<a class="n" data-link-type="idl-name" href="#receivestream" id="ref-for-receivestream③①"><c- n>ReceiveStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream" id="ref-for-incomingstream①③①"><c- n>IncomingStream</c-></a>;
+<a class="n" data-link-type="idl-name" href="#receivestream"><c- n>ReceiveStream</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#incomingstream"><c- n>IncomingStream</c-></a>;
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑥①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
-<c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#http3transport" id="ref-for-http3transport⑥"><c- g>Http3Transport</c-></a> {
-  <a href="#dom-http3transport-http3transport"><code><c- g>constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a> <a href="#dom-http3transport-constructor-url-url"><code><c- g>url</c-></code></a>);
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
+<c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#http3transport"><c- g>Http3Transport</c-></a> {
+  <a href="#dom-http3transport-http3transport"><code><c- g>constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-http3transport-http3transport-url-url"><code><c- g>url</c-></code></a>);
 };
 
-<a class="n" data-link-type="idl-name" href="#http3transport" id="ref-for-http3transport①①"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#unidirectionalstreamstransport" id="ref-for-unidirectionalstreamstransport⑥①"><c- n>UnidirectionalStreamsTransport</c-></a>;
-<a class="n" data-link-type="idl-name" href="#http3transport" id="ref-for-http3transport②①"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#bidirectionalstreamstransport" id="ref-for-bidirectionalstreamstransport⑦①"><c- n>BidirectionalStreamsTransport</c-></a>;
-<a class="n" data-link-type="idl-name" href="#http3transport" id="ref-for-http3transport③①"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#datagramtransport" id="ref-for-datagramtransport⑤①"><c- n>DatagramTransport</c-></a>;
-<a class="n" data-link-type="idl-name" href="#http3transport" id="ref-for-http3transport④①"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#webtransport" id="ref-for-webtransport⑨①"><c- n>WebTransport</c-></a>;
+<a class="n" data-link-type="idl-name" href="#http3transport"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#unidirectionalstreamstransport"><c- n>UnidirectionalStreamsTransport</c-></a>;
+<a class="n" data-link-type="idl-name" href="#http3transport"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#bidirectionalstreamstransport"><c- n>BidirectionalStreamsTransport</c-></a>;
+<a class="n" data-link-type="idl-name" href="#http3transport"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#datagramtransport"><c- n>DatagramTransport</c-></a>;
+<a class="n" data-link-type="idl-name" href="#http3transport"><c- n>Http3Transport</c-></a> <c- b>includes</c-> <a class="n" data-link-type="idl-name" href="#webtransport"><c- n>WebTransport</c-></a>;
 
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
@@ -3309,6 +3332,7 @@ without key rotation.<a href="#issue-7e6950b7"> ↵ </a></div>
    <b><a href="#dom-unidirectionalstreamstransport-receivestreams">#dom-unidirectionalstreamstransport-receivestreams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-unidirectionalstreamstransport-receivestreams">4. UnidirectionalStreamsTransport Mixin</a>
+    <li><a href="#ref-for-dom-unidirectionalstreamstransport-receivestreams①">16.4. Receiving from ReceiveStream</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="add-the-sendstream">
@@ -3561,17 +3585,17 @@ without key rotation.<a href="#issue-7e6950b7"> ↵ </a></div>
     <li><a href="#ref-for-quictransport⑦">17. Acknowledgements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-quictransportconfiguration">
-   <b><a href="#dictdef-quictransportconfiguration">#dictdef-quictransportconfiguration</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dictdef-quictransportoptions">
+   <b><a href="#dictdef-quictransportoptions">#dictdef-quictransportoptions</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-quictransportconfiguration">8.1. Configuration</a>
-    <li><a href="#ref-for-dictdef-quictransportconfiguration①">8.2. Interface Definition</a>
+    <li><a href="#ref-for-dictdef-quictransportoptions">8.1. Configuration</a>
+    <li><a href="#ref-for-dictdef-quictransportoptions①">8.2. Interface Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-quictransportconfiguration-server_certificate_fingerprints">
-   <b><a href="#dom-quictransportconfiguration-server_certificate_fingerprints">#dom-quictransportconfiguration-server_certificate_fingerprints</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-quictransportoptions-servercertificatefingerprints">
+   <b><a href="#dom-quictransportoptions-servercertificatefingerprints">#dom-quictransportoptions-servercertificatefingerprints</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-quictransportconfiguration-server_certificate_fingerprints">8.1. Configuration</a> <a href="#ref-for-dom-quictransportconfiguration-server_certificate_fingerprints①">(2)</a>
+    <li><a href="#ref-for-dom-quictransportoptions-servercertificatefingerprints">8.1. Configuration</a> <a href="#ref-for-dom-quictransportoptions-servercertificatefingerprints①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="compute-a-certificate-fingerprint">
@@ -3598,16 +3622,16 @@ without key rotation.<a href="#issue-7e6950b7"> ↵ </a></div>
     <li><a href="#ref-for-dom-quictransport-quictransport">8.2. Interface Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-quictransport-constructor-url-config-url">
-   <b><a href="#dom-quictransport-constructor-url-config-url">#dom-quictransport-constructor-url-config-url</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-quictransport-quictransport-url-options-url">
+   <b><a href="#dom-quictransport-quictransport-url-options-url">#dom-quictransport-quictransport-url-options-url</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-quictransport-constructor-url-config-url">8.2. Interface Definition</a>
+    <li><a href="#ref-for-dom-quictransport-quictransport-url-options-url">8.2. Interface Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-quictransport-constructor-url-config-config">
-   <b><a href="#dom-quictransport-constructor-url-config-config">#dom-quictransport-constructor-url-config-config</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-quictransport-quictransport-url-options-options">
+   <b><a href="#dom-quictransport-quictransport-url-options-options">#dom-quictransport-quictransport-url-options-options</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-quictransport-constructor-url-config-config">8.2. Interface Definition</a>
+    <li><a href="#ref-for-dom-quictransport-quictransport-url-options-options">8.2. Interface Definition</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-quictransport-outgoingstreams-slot">
@@ -3801,6 +3825,7 @@ without key rotation.<a href="#issue-7e6950b7"> ↵ </a></div>
     <li><a href="#ref-for-receivestream②">10. Interface Mixin IncomingStream</a>
     <li><a href="#ref-for-receivestream③">13. Interface ReceiveStream</a>
     <li><a href="#ref-for-receivestream④">14.1. Overview</a>
+    <li><a href="#ref-for-receivestream⑤">16.4. Receiving from ReceiveStream</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="http3transport">
@@ -3816,6 +3841,62 @@ without key rotation.<a href="#issue-7e6950b7"> ↵ </a></div>
     <li><a href="#ref-for-dom-http3transport-http3transport">14.2.1. Constructors</a>
    </ul>
   </aside>
+<script>/* script-dfn-panel */
+
+document.body.addEventListener("click", function(e) {
+    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+    // Find the dfn element or panel, if any, that was clicked on.
+    var el = e.target;
+    var target;
+    var hitALink = false;
+    while(el.parentElement) {
+        if(el.tagName == "A") {
+            // Clicking on a link in a <dfn> shouldn't summon the panel
+            hitALink = true;
+        }
+        if(el.classList.contains("dfn-paneled")) {
+            target = "dfn";
+            break;
+        }
+        if(el.classList.contains("dfn-panel")) {
+            target = "dfn-panel";
+            break;
+        }
+        el = el.parentElement;
+    }
+    if(target != "dfn-panel") {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+            el.classList.remove("on");
+            el.classList.remove("activated");
+        });
+    }
+    if(target == "dfn" && !hitALink) {
+        // open the panel
+        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+        if(dfnPanel) {
+            dfnPanel.classList.add("on");
+            var rect = el.getBoundingClientRect();
+            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+            dfnPanel.style.top = window.scrollY + rect.top + "px";
+            var panelRect = dfnPanel.getBoundingClientRect();
+            var panelWidth = panelRect.right - panelRect.left;
+            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                // Reposition, because the panel is overflowing
+                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+            }
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+        }
+    } else if(target == "dfn-panel") {
+        // Switch it to "activated" state, which pins it.
+        el.classList.add("activated");
+        el.style.left = null;
+        el.style.top = null;
+    }
+
+});
+</script>
 <script>/* script-var-click-highlighting */
 
     document.addEventListener("click", e=>{
@@ -3900,59 +3981,3 @@ without key rotation.<a href="#issue-7e6950b7"> ↵ </a></div>
         }
     }
     </script>
-<script>/* script-dfn-panel */
-
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
-    }
-
-});
-</script>


### PR DESCRIPTION
Rename QuicTransportConfiguration to QuicTransportOptions to better
match web platform conventions. Also change
server_certificate_fingerprints to serverCertificateFingerprints.

As a side effect of regenerating index.html, incorporate the
ReceiveStreams example from #114 into the visible standard.

As a side effect of using a different version of Bikeshed, has some CSS
changes and updates the links to the Streams Standard to the latest
version.

Fixes #120.